### PR TITLE
Fix replication step confusion

### DIFF
--- a/tutorials/get-started-turso-cli/step-05-replicate-database-another-location.md
+++ b/tutorials/get-started-turso-cli/step-05-replicate-database-another-location.md
@@ -9,13 +9,15 @@ keywords:
 
 # Step 5: Replicate the database to another location
 
-## Understand placement groups
+:::note
 
 In step 3, you created a database in a [placement group] named "default" with a
 primary [location] near you. The placement group defines the set of locations
 where the database is replicated. When you create additional databases in this
 group it will also exist in the same set of locations, all hosted by the same
 hardware at those locations.
+
+:::
 
 ## Replicate a database by adding a location to its placement group
 


### PR DESCRIPTION
The page starts out with "understanding placement groups", which can be confusing when someone comes to the page via a link, like from Prisma's blog post.

Change the bit into a note to make it more obvious that it's giving some background information.

Reported by Jan Piotrowski