### PR TITLE
Update step-03-configuring-drizzle.md

### DIFF
--- a/tutorials/e-commerce-store-codelab/step-03-configuring-drizzle.md
+++ b/tutorials/e-commerce-store-codelab/step-03-configuring-drizzle.md
@@ -297,7 +297,7 @@ task.
 "migrate": "tsx drizzle/migrate",
 ```
 
-Then, Run the migration task npm `run migrate`.
+Then, Run the migration task `npm run migrate`.
 
 If everything went well, you should see the following log output.
 


### PR DESCRIPTION
`npm run migrate` inline snippet was incorrectly formatted and only `run migrate` was shown as highlighted.