### PR TITLE
Fix link to the REST API to avoid 404 errors

### DIFF
--- a/reference/index.md
+++ b/reference/index.md
@@ -24,5 +24,5 @@ and server [components].
 
 
 [Turso CLI]: turso-cli
-[Platform REST API]: platform-rest-API
+[Platform REST API]: platform-rest-api
 [components]: /libsql/


### PR DESCRIPTION
On the [reference docs](https://docs.turso.tech/reference/) we have a link to https://docs.turso.tech/reference/platform-rest-API that returns a 404. However, this appears to happen only if you click on the link directly from that page (I got a 304 if I copy-paste the link). You can reload the page after going from the link and still get a 404, which is weird but it's what's happening.

This PR fixes that issue by updating the url to use lowercase.