### PR TITLE
add retrieve database credentials step

### DIFF
--- a/sdk/go/quickstart.mdx
+++ b/sdk/go/quickstart.mdx
@@ -14,12 +14,23 @@ Embedded Replicas with Go are experimental and may break. It's recommended you u
 
 In this Go quickstart we will learn how to:
 
+- Retrieve database credentials
 - Install Go libSQL
 - Connect to a local or remote Turso database
 - Execute a query using SQL
 - Sync changes to local database (optional)
 
 <Steps>
+  <Step title="Retrieve database credentials">
+
+You will need an existing database to continue. If you don't have one, [create one](/quickstart).
+
+<Snippet file="retrieve-database-credentials.mdx" />
+
+<Info>You will want to store these as environment variables.</Info>
+
+  </Step>
+
   <Step title="Install">
 
 First begin by adding libSQL to your project:

--- a/sdk/rust/quickstart.mdx
+++ b/sdk/rust/quickstart.mdx
@@ -6,11 +6,22 @@ description: Get started with Turso and Rust using the libSQL client in a few si
 
 In this Rust quickstart we will learn how to:
 
+- Retrieve database credentials
 - Install the Rust libSQL client
 - Connect to a remote Turso database
 - Execute a query using SQL
 
 <Steps>
+  <Step title="Retrieve database credentials">
+
+You will need an existing database to continue. If you don't have one, [create one](/quickstart).
+
+<Snippet file="retrieve-database-credentials.mdx" />
+
+<Info>You will want to store these as environment variables.</Info>
+
+  </Step>
+
   <Step title="Install libsql-client">
 
 First begin by installing the `libsql-client` [crate](https://crates.io/crates/libsql-client):

--- a/sdk/ts/quickstart.mdx
+++ b/sdk/ts/quickstart.mdx
@@ -6,11 +6,22 @@ description: Get started with Turso and TypeScript using the libSQL client in a 
 
 In this JavaScript quickstart we will learn how to:
 
+- Retrieve database credentials
 - Install the JavaScript libSQL client
 - Connect to a remote Turso database
 - Execute a query using SQL
 
 <Steps>
+  <Step title="Retrieve database credentials">
+
+You will need an existing database to continue. If you don't have one, [create one](/quickstart).
+
+<Snippet file="retrieve-database-credentials.mdx" />
+
+<Info>You will want to store these as environment variables.</Info>
+
+  </Step>
+
   <Step title="Install @libsql/client">
 
 First begin by installing the `@libsql/client`:


### PR DESCRIPTION
All Client SDK quickstarts assume you have the database URL and token already. It doesn't mention how to retrieve them.

This PR fixes that.