### PR TITLE
fix the response key for db usage

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1924,7 +1924,7 @@
               }
             ]
           },
-          "usage": {
+          "total": {
             "description": "The total usage for the database.",
             "$ref": "#/components/schemas/DatabaseUsageObject",
             "example": {


### PR DESCRIPTION
The current API responds with the key as `total` for the total database usage endpoint, however in the docs, the key was wrongly showing as `usage`.
![image](https://github.com/tursodatabase/turso-docs/assets/40317114/380ced41-3ef5-4717-ac55-20cb91b2e4aa)
