### PR TITLE
change "personal" to "Starter"

### DIFF
--- a/cli/group/wakeup.mdx
+++ b/cli/group/wakeup.mdx
@@ -3,7 +3,7 @@ title: group wakeup
 sidebarTitle: wakeup
 ---
 
-Users of the free personal plan can wakeup inactive databases by running the following command:
+Users of the free Starter plan can wakeup inactive databases by running the following command:
 
 ```bash
 turso group update <group-name> [flags]


### PR DESCRIPTION
Just want to change the language to clarify “Starter” instead of using the word “personal” - sorry if the etiquette is to discuss first, just figured this is would be appropriate for such a simple change. Happy to follow protocol in the future as necessary. 