### PR TITLE
fix remix docs

### DIFF
--- a/sdk/ts/guides/remix.mdx
+++ b/sdk/ts/guides/remix.mdx
@@ -62,19 +62,12 @@ TURSO_AUTH_TOKEN="..."
 <Step title="Configure LibSQL Client.">
 
 ```ts app/lib/turso.ts
-import { createClient } from "@libsql/client/http";
-import { AppLoadContext } from "@remix-run/node";
+import { createClient } from "@libsql/client";
 
-interface Env {
-  TURSO_AUTH_TOKEN?: string;
-  TURSO_DATABASE_URL?: string;
-}
-
-export const turso = (serverContext: AppLoadContext) =>
-  createClient({
-    url: serverContext.env.TURSO_DATABASE_URL,
-    authToken: serverContext.env.TURSO_AUTH_TOKEN,
-  });
+export const turso = createClient({
+    url: process.env.TURSO_DATABASE_URL,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+});
 ```
 
 </Step>
@@ -82,13 +75,11 @@ export const turso = (serverContext: AppLoadContext) =>
 <Step title="Execute SQL">
 
 ```ts app/routes/_index.ts
-import type { LoaderArgs, LoaderFunction } from "@remix-run/node";
-import { buildDbClient } from "~/lib/turso";
+import type { LoaderFunction } from "@remix-run/node";
+import { turso } from "~/lib/turso";
 
-export const loader: LoaderFunction = async ({ context }: LoaderArgs) => {
-  const db = turso(context);
-
-  const { rows } = await db.execute("select * from table_name");
+export const loader: LoaderFunction = async () => {
+  const { rows } = await turso.execute("SELECT * from TABLE_NAME");
 
   return {
     items: rows,


### PR DESCRIPTION
The current docs for Remix were containing some issues:
- The import is forced to `http` with `@libsql/client/http`, while I think it's better to let the environment import what it will need
- The environment variables were defined through `AppLoadContext`, but it's only recommended for a specific case of [local development](https://remix.run/docs/en/main/guides/envvars#local-development). I think recommending `process.env` and letting the user choose how to handle its type is generally better 
- A small typo in the import of the turso client in `app/routes/_index.tsx` (`buildDbClient` instead of `turso`)
- A redundant type `LoaderArgs` which is deprecated (see [here](https://github.com/remix-run/remix/pull/7319)) and already covered by `LoaderFunction` (see below)

```ts
export type LoaderFunction = (args: LoaderFunctionArgs) => ReturnType<RRLoaderFunction>;
```
