### PR TITLE
docs: update data edge link on concepts page

### DIFF
--- a/concepts.mdx
+++ b/concepts.mdx
@@ -35,7 +35,7 @@ All databases are part of a "group", dictating their primary storage location an
 
 ## Locations
 
-Turso optimizes data access with control over data storage and replication across global locations. Your databases form a [group](#groups) with a primary and optional replica locations, ensuring low latency. Turso handles synchronization automatically across its [data edge](/data-edge).
+Turso optimizes data access with control over data storage and replication across global locations. Your databases form a [group](#groups) with a primary and optional replica locations, ensuring low latency. Turso handles synchronization automatically across its [data edge](/features/data-edge).
 
 - **Primary**
   - All databases have a primary location (region) where data is stored, and can't be changed. You can configure the primary location for groups using the Turso CLI and Turso Platform API.


### PR DESCRIPTION
Data edge link is not working on the [Concept page](https://docs.turso.tech/concepts#locations).
I updated it to point to `/features/data-edge`.