### PR TITLE
Update SvelteKit guide to use framework conventions

### DIFF
--- a/sdk/ts/guides/sveltekit.mdx
+++ b/sdk/ts/guides/sveltekit.mdx
@@ -53,20 +53,21 @@ turso db tokens create <database-name>
 Assign credentials to the environment variables inside `.env.local`.
 
 ```bash
-VITE_TURSO_DATABASE_URL="..."
-VITE_TURSO_AUTH_TOKEN="..."
+TURSO_DATABASE_URL="..."
+TURSO_AUTH_TOKEN="..."
 ```
 
 </Step>
 
 <Step title="Configure LibSQL Client.">
 
-```ts src/turso.ts
+```ts src/lib/turso.server.ts
+import { TURSO_DATABASE_URL, TURSO_AUTH_TOKEN } from "$env/static/private";
 import { createClient } from "@libsql/client/web";
 
-export const tursoClient = createClient({
-  url: process.env.TURSO_DATABASE_URL!,
-  authToken: process.env.TURSO_AUTH_TOKEN,
+export const turso = createClient({
+  url: TURSO_DATABASE_URL,
+  authToken: TURSO_AUTH_TOKEN,
 });
 ```
 
@@ -74,11 +75,15 @@ export const tursoClient = createClient({
 
 <Step title="Execute SQL">
 
-```ts
+```ts src/routes/+page.server.ts
 ---
-import { turso } from './turso'
+import { turso } from '$lib/turso.server'
 
-const { rows } = await tursoClient.execute('SELECT * FROM table_name')
+export async function load() {
+  const { rows } = await turso.execute('SELECT * FROM table_name')
+
+  return { rows }
+}
 ---
 ```
 

--- a/sdk/ts/guides/sveltekit.mdx
+++ b/sdk/ts/guides/sveltekit.mdx
@@ -75,8 +75,9 @@ export const turso = createClient({
 
 <Step title="Execute SQL">
 
+<CodeGroup>
+
 ```ts src/routes/+page.server.ts
----
 import { turso } from '$lib/turso.server'
 
 export async function load() {
@@ -84,8 +85,21 @@ export async function load() {
 
   return { rows }
 }
----
 ```
+
+```svelte src/routes/+page.svelte
+<script lang="ts">
+  export let data
+</script>
+
+<ul>
+  {#each data.rows as row}
+    <li>{row.id}</li>
+  {/each}
+</ul>
+```
+
+</CodeGroup>
 
 </Step>
 

--- a/sdk/ts/guides/sveltekit.mdx
+++ b/sdk/ts/guides/sveltekit.mdx
@@ -63,7 +63,7 @@ TURSO_AUTH_TOKEN="..."
 
 ```ts src/lib/turso.server.ts
 import { TURSO_DATABASE_URL, TURSO_AUTH_TOKEN } from "$env/static/private";
-import { createClient } from "@libsql/client/web";
+import { createClient } from "@libsql/client"; // or from '@libsql/client/web' for Edge runtimes
 
 export const turso = createClient({
   url: TURSO_DATABASE_URL,

--- a/sdk/ts/guides/sveltekit.mdx
+++ b/sdk/ts/guides/sveltekit.mdx
@@ -50,7 +50,7 @@ Get the database authentication token.
 turso db tokens create <database-name>
 ```
 
-Assign credentials to the environment variables inside `.env.local`.
+Assign credentials to the environment variables inside `.env`.
 
 ```bash
 TURSO_DATABASE_URL="..."


### PR DESCRIPTION
- Use the SvelteKit way of importing env vars
- Store the client export in the more conventional src/lib directory 
- Use a working 'load' function as the client usage example
- Use .server.ts files to guarantee only server side usage (in order to not accidentally leak the authToken to any front-end)