### PR TITLE
Update introduction.mdx Windows support is only WSL

### DIFF
--- a/cli/introduction.mdx
+++ b/cli/introduction.mdx
@@ -22,7 +22,7 @@ brew install tursodatabase/tap/turso
 curl -sSfL https://get.tur.so/install.sh | bash
 ```
 
-```bash Windows
+```bash Windows (WSL)
 curl -sSfL https://get.tur.so/install.sh | bash
 ```
 


### PR DESCRIPTION
The first step was misleading as windows doesn't have curl and bash in the default setup.