### PR TITLE
Updated Go local quickstart docs to include file: scheme

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -52,7 +52,7 @@ import (
 )
 
 func main() {
-  dbName := "./local.db"
+  dbName := "file:./local.db"
 
   db, err := sql.Open("libsql", dbName)
   if err != nil {

--- a/sdk/go/quickstart.mdx
+++ b/sdk/go/quickstart.mdx
@@ -49,7 +49,7 @@ First begin by adding libSQL to your project:
     ```
 
   </Accordion>
- 
+
 </AccordionGroup>
 
   </Step>
@@ -115,7 +115,7 @@ Now connect to your local or remote database using the libSQL connector:
     )
 
     func main() {
-      dbName := "./local.db"
+      dbName := "file:./local.db"
 
       db, err := sql.Open("libsql", dbName)
       if err != nil {


### PR DESCRIPTION
The quick start and local setup for Go needs `file:` prefix as part of the database name in order to work properly. May save someone time in the future trying to figure out what is wrong.

Can see the switch case checking the URL scheme and using correct connector: https://github.com/tursodatabase/go-libsql/blob/08771dcdd2f1c0c7d204fb10402c03aa3afc7b06/libsql.go#L146