### PR TITLE
Fix typo in quickstart.mdx

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -147,7 +147,7 @@ turso group locations add default nrt
 
 </Step>
 
-<Step title="Connect your application your database">
+<Step title="Connect your application to your database">
 
 You're now ready to connect your application to your database. Pick from one of the SDKs below to continue:
 


### PR DESCRIPTION
"to" was omitted in a header.