### PR TITLE
refactor: reuse snippets and cleanup guides

### DIFF
--- a/_snippets/all-sdks.mdx
+++ b/_snippets/all-sdks.mdx
@@ -1,5 +1,4 @@
 <Snippet file="official-sdks.mdx" />
-<Snippet file="experimental-sdks.mdx" />
 <CardGroup cols={2}>
   <Snippet file="http-sdk.mdx" />
 </CardGroup>

--- a/_snippets/configure-libsql-client-ts.mdx
+++ b/_snippets/configure-libsql-client-ts.mdx
@@ -1,0 +1,30 @@
+<CodeGroup>
+
+```ts Node.js
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+```
+
+```ts Edge Runtimes
+import { createClient } from "@libsql/client/web";
+
+const client = createClient({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+```
+
+```ts Deno
+import { createClient } from "https://esm.sh/@libsql/client@0.6.0/web";
+
+const client = createClient({
+  url: Deno.env.get("TURSO_DATABASE_URL"),
+  authToken: Deno.env.get("TURSO_AUTH_TOKEN"),
+});
+```
+
+</CodeGroup>

--- a/_snippets/experimental-sdks.mdx
+++ b/_snippets/experimental-sdks.mdx
@@ -1,9 +1,0 @@
-<CardGroup cols={2}>
-  <Card
-    title="Python"
-    icon="python"
-    href="https://github.com/tursodatabase/libsql-experimental-python"
-  >
-    Get started with Turso, libSQL and Python.
-  </Card>
-</CardGroup>

--- a/_snippets/install-libsql-client-ts.mdx
+++ b/_snippets/install-libsql-client-ts.mdx
@@ -1,0 +1,17 @@
+Begin by installing the `@libsql/client` dependency in your project:
+
+<CodeGroup>
+
+```bash npm
+npm install @libsql/client
+```
+
+```bash pnpm
+pnpm install @libsql/client
+```
+
+```bash yarn
+yarn add @libsql/client
+```
+
+</CodeGroup>

--- a/_snippets/official-sdks.mdx
+++ b/_snippets/official-sdks.mdx
@@ -8,4 +8,11 @@
   <Card title="Go" icon="golang" href="/sdk/go/quickstart">
     Get started with Turso, libSQL and Go.
   </Card>
+  <Card
+    title="Python"
+    icon="python"
+    href="https://github.com/tursodatabase/libsql-experimental-python"
+  >
+    Get started with Turso, libSQL and Python.
+  </Card>
 </CardGroup>

--- a/_snippets/retrieve-database-credentials.mdx
+++ b/_snippets/retrieve-database-credentials.mdx
@@ -1,19 +1,18 @@
-<AccordionGroup>
-
-<Accordion title="Get database URL">
+Get the database URL:
 
 ```bash
-turso db show <database-name> --url
+turso db show --url <database-name>
 ```
 
-</Accordion>
-
-<Accordion title="Create database auth token">
+Get the database authentication token:
 
 ```bash
 turso db tokens create <database-name>
 ```
 
-</Accordion>
+Assign credentials to the environment variables inside `.env`.
 
-</AccordionGroup>
+```bash
+TURSO_DATABASE_URL=
+TURSO_AUTH_TOKEN=
+```

--- a/sdk/http/guides/flutter.mdx
+++ b/sdk/http/guides/flutter.mdx
@@ -24,15 +24,15 @@ dart pub add http
 
 </Step>
 
-<Step title="Configure database credentials">
+<Step title="Retrieve database credentials">
 
-Get the database URL.
+Get the database URL:
 
 ```bash
 turso db show --url <database-name>
 ```
 
-Get the database authentication token.
+Get the database authentication token:
 
 ```bash
 turso db tokens create <database-name>

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -10,10 +10,6 @@ Turso SDKs are fully compatible with [libSQL](/libsql), so you can use the same 
 
 <Snippet file="official-sdks.mdx" />
 
-## Experimental SDKs
-
-<Snippet file="experimental-sdks.mdx" />
-
 ## Turso over HTTP
 
 <CardGroup cols={2}>

--- a/sdk/python/guides/flask.mdx
+++ b/sdk/python/guides/flask.mdx
@@ -18,32 +18,15 @@ Before you start, make sure you:
 
 <Step title="Install the libSQL dialect">
 
-```bash npm
+```bash
 pip install sqlalchemy-libsql python-dotenv
 ```
 
 </Step>
 
-<Step title="Comfigure database credentials.">
+<Step title="Retrieve database credentials">
 
-Get the database URL.
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token.
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env`.
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
@@ -69,9 +52,9 @@ class Item(Base):
 
 </Step>
 
-<Step title="Query database">
+<Step title="Query">
 
-```python app.py
+```python
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session

--- a/sdk/python/orm/sqlalchemy.mdx
+++ b/sdk/python/orm/sqlalchemy.mdx
@@ -23,26 +23,9 @@ pip install sqlalchemy-libsql
 
 </Step>
 
-<Step title="Configure database credentials">
+<Step title="Retrieve database credentials">
 
-Get the database URL:
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token:
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env`.
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
@@ -84,7 +67,7 @@ engine = create_engine(dbUrl, connect_args={'check_same_thread': False}, echo=Tr
 
 </Step>
 
-<Step title="Query database">
+<Step title="Query">
 
 ```py app.py
 from sqlalchemy.orm import Session

--- a/sdk/ts/guides/astro.mdx
+++ b/sdk/ts/guides/astro.mdx
@@ -18,44 +18,13 @@ To get the most out of this guide, you'll need to:
 
 <Step title="Install the libSQL SDK">
 
-<CodeGroup>
-
-```bash npm
-npm install @libsql/client
-```
-
-```bash pnpm
-pnpm add @libsql/client
-```
-
-```bash yarn
-yarn add @libsql/client
-```
-
-</CodeGroup>
+<Snippet file="install-libsql-client-ts.mdx" />
 
 </Step>
 
 <Step title="Configure database credentials">
 
-Get the database URL.
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token.
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env.local`:
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 

--- a/sdk/ts/guides/elysia.mdx
+++ b/sdk/ts/guides/elysia.mdx
@@ -18,58 +18,31 @@ Before you start, make sure you:
 
 <Step title="Install the libSQL SDK">
 
-```bash bun
-bun add @libsql/client
-```
+<Snippet file="install-libsql-client-ts.mdx" />
 
 </Step>
 
-<Step title="Configure database credentials">
+<Step title="Retrieve database credentials">
 
-Get the database URL:
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token:
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env`:
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
 <Step title="Configure LibSQL client">
 
-```ts index.ts
-import { createClient } from "@libsql/client";
-
-export const db = createClient({
-  url: process.env.TURSO_DATABASE_URL,
-  authToken: process.env.TURSO_AUTH_TOKEN,
-});
-```
+<Snippet file="configure-libsql-client-ts.mdx" />
 
 </Step>
 
 <Step title="Execute SQL">
 
-```tsx index.ts
+```ts
 import { Elysia } from "elysia";
 
-const app = new Elysia()
-  .get("/items", async () => {
-      const { rows } = await db.execute("SELECT * FROM items");
-      return rows;
-    })
+const app = new Elysia().get("/items", async () => {
+  const { rows } = await db.execute("SELECT * FROM items");
+  return rows;
+});
 ```
 
 </Step>

--- a/sdk/ts/guides/hono.mdx
+++ b/sdk/ts/guides/hono.mdx
@@ -18,30 +18,25 @@ Before you start, make sure you:
 
 <Step title="Install the libSQL SDK">
 
-```bash bun
-bun add @libsql/client
-```
+<Snippet file="install-libsql-client-ts.mdx" />
 
 </Step>
 
+<Step title="Retrieve database credentials">
+
 <Snippet file="retrieve-database-credentials.mdx" />
+
+</Step>
 
 <Step title="Configure LibSQL client">
 
-```ts index.ts
-import { createClient } from "@libsql/client";
-
-export const db = createClient({
-  url: process.env.TURSO_DATABASE_URL,
-  authToken: process.env.TURSO_AUTH_TOKEN,
-});
-```
+<Snippet file="configure-libsql-client-ts.mdx" />
 
 </Step>
 
 <Step title="Execute SQL">
 
-```tsx index.ts
+```ts
 import { Hono } from "hono";
 
 const app = new Hono();

--- a/sdk/ts/guides/nextjs.mdx
+++ b/sdk/ts/guides/nextjs.mdx
@@ -18,58 +18,19 @@ Before you start, make sure you:
 
 <Step title="Install the libSQL SDK">
 
-<CodeGroup>
-
-```bash npm
-npm install @libsql/client
-```
-
-```bash pnpm
-pnpm add @libsql/client
-```
-
-```bash yarn
-yarn add @libsql/client
-```
-
-</CodeGroup>
+<Snippet file="install-libsql-client-ts.mdx" />
 
 </Step>
 
 <Step title="Configure database credentials">
 
-Get the database URL:
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token:
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env.local`:
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
 <Step title="Configure LibSQL client">
 
-```ts lib/turso.ts
-import { createClient } from "@libsql/client";
-// import { createClient } from "@libsql/client/web";
-
-export const turso = createClient({
-  url: process.env.TURSO_DATABASE_URL!,
-  authToken: process.env.TURSO_AUTH_TOKEN,
-});
-```
+<Snippet file="configure-libsql-client-ts.mdx" />
 
 </Step>
 

--- a/sdk/ts/guides/nuxt.mdx
+++ b/sdk/ts/guides/nuxt.mdx
@@ -16,44 +16,13 @@ Before you start, make sure you:
 
 <Step title="Install the libSQL SDK">
 
-<CodeGroup>
-
-```bash npm
-npm install @libsql/client
-```
-
-```bash pnpm
-pnpm add @libsql/client
-```
-
-```bash yarn
-yarn add @libsql/client
-```
-
-</CodeGroup>
+<Snippet file="install-libsql-client-ts.mdx" />
 
 </Step>
 
 <Step title="Configure database credentials">
 
-Get the database URL.
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token.
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env`.
-
-```bash
-NUXT_TURSO_DATABASE_URL="..."
-NUXT_TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
@@ -71,9 +40,10 @@ export default defineNuxtConfig({
 ```
 
 <Note>
-  Make sure that names of the keys in the `runtimeConfig` object match the names of your environment variables. Read more about this [here](https://nitro.unjs.io/guide/configuration#runtime-configuration).
+  Make sure that names of the keys in the `runtimeConfig` object match the names
+  of your environment variables. Read more about this
+  [here](https://nitro.unjs.io/guide/configuration#runtime-configuration).
 </Note>
-
 
 </Step>
 
@@ -86,12 +56,12 @@ import { createClient } from "@libsql/client";
 
 export function useTurso(/* event: H3Event */) {
   const { turso } = useRuntimeConfig(/* event */);
-  
+
   return createClient({
     url: turso.databaseUrl,
     authToken: turso.authToken,
   });
-};
+}
 ```
 
 </Step>

--- a/sdk/ts/guides/quasar.mdx
+++ b/sdk/ts/guides/quasar.mdx
@@ -18,33 +18,19 @@ Before you start, make sure you:
 
 <Step title="Install the libSQL SDK">
 
-<CodeGroup>
-
-```bash npm
-npm install @libsql/client
-```
-
-```bash pnpm
-pnpm add @libsql/client
-```
-
-```bash yarn
-yarn add @libsql/client
-```
-
-</CodeGroup>
+<Snippet file="install-libsql-client-ts.mdx" />
 
 </Step>
 
 <Step title="Configure database credentials">
 
-Get the database URL.
+Get the database URL:
 
 ```bash
 turso db show --url <database-name>
 ```
 
-Get the database authentication token.
+Get the database authentication token:
 
 ```bash
 turso db tokens create <database-name>
@@ -61,14 +47,13 @@ VITE_TURSO_AUTH_TOKEN="..."
 
 <Step title="Configure LibSQL Client">
 
-```javascript IndexPage.vue
-import {createClient} from '@libsql/client/web';
+```js
+import { createClient } from "@libsql/client/web";
 
 const turso = createClient({
-  url: import.meta.env.VITE_TURSO_URL,
+  url: import.meta.env.VITE_TURSO_DATABASE_URL,
   authToken: import.meta.env.VITE_TURSO_AUTH_TOKEN,
 });
-}
 ```
 
 <Info>
@@ -101,7 +86,7 @@ const turso = createClient({
 
 <Step title="Fetch data from Turso.">
 
-```javascript IndexPage.vue
+```js IndexPage.vue
 import { ref } from "vue";
 
 const items = ref();

--- a/sdk/ts/guides/qwik.mdx
+++ b/sdk/ts/guides/qwik.mdx
@@ -38,13 +38,13 @@ yarn qwik add turso
 
 <Step title="Configure database credentials">
 
-Get the database URL.
+Get the database URL:
 
 ```bash
 turso db show --url <database-name>
 ```
 
-Get the database authentication token.
+Get the database authentication token:
 
 ```bash
 turso db tokens create <database-name>

--- a/sdk/ts/guides/remix.mdx
+++ b/sdk/ts/guides/remix.mdx
@@ -18,57 +18,19 @@ Before you start, make sure you:
 
 <Step title="Install the libSQL SDK">
 
-<CodeGroup>
-
-```bash npm
-npm install @libsql/client
-```
-
-```bash pnpm
-pnpm add @libsql/client
-```
-
-```bash yarn
-yarn add @libsql/client
-```
-
-</CodeGroup>
+<Snippet file="install-libsql-client-ts.mdx" />
 
 </Step>
 
 <Step title="Configure database credentials">
 
-Get the database URL.
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token.
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env`.
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
 <Step title="Configure LibSQL Client.">
 
-```ts app/lib/turso.ts
-import { createClient } from "@libsql/client";
-
-export const turso = createClient({
-    url: process.env.TURSO_DATABASE_URL,
-    authToken: process.env.TURSO_AUTH_TOKEN,
-});
-```
+<Snippet file="configure-libsql-client-ts.mdx" />
 
 </Step>
 

--- a/sdk/ts/guides/sveltekit.mdx
+++ b/sdk/ts/guides/sveltekit.mdx
@@ -18,58 +18,41 @@ Before you start, make sure you:
 
 <Step title="Install the libSQL SDK">
 
-<CodeGroup>
-
-```bash npm
-npm install @libsql/client
-```
-
-```bash pnpm
-pnpm add @libsql/client
-```
-
-```bash yarn
-yarn add @libsql/client
-```
-
-</CodeGroup>
+<Snippet file="install-libsql-client-ts.mdx" />
 
 </Step>
 
 <Step title="Configure database credentials">
 
-Get the database URL.
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token.
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env`.
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
 <Step title="Configure LibSQL Client.">
 
-```ts src/lib/turso.server.ts
+<CodeGroup>
+
+```ts Node.js / Serverless
 import { TURSO_DATABASE_URL, TURSO_AUTH_TOKEN } from "$env/static/private";
-import { createClient } from "@libsql/client"; // or from '@libsql/client/web' for Edge runtimes
+import { createClient } from "@libsql/client";
 
 export const turso = createClient({
   url: TURSO_DATABASE_URL,
   authToken: TURSO_AUTH_TOKEN,
 });
 ```
+
+```ts Edge Runtimes
+import { TURSO_DATABASE_URL, TURSO_AUTH_TOKEN } from "$env/static/private";
+import { createClient } from "@libsql/client/web";
+
+export const turso = createClient({
+  url: TURSO_DATABASE_URL,
+  authToken: TURSO_AUTH_TOKEN,
+});
+```
+
+</CodeGroup>
 
 </Step>
 
@@ -78,12 +61,12 @@ export const turso = createClient({
 <CodeGroup>
 
 ```ts src/routes/+page.server.ts
-import { turso } from '$lib/turso.server'
+import { turso } from "$lib/turso.server";
 
 export async function load() {
-  const { rows } = await turso.execute('SELECT * FROM table_name')
+  const { rows } = await turso.execute("SELECT * FROM table_name");
 
-  return { rows }
+  return { rows };
 }
 ```
 

--- a/sdk/ts/orm/drizzle.mdx
+++ b/sdk/ts/orm/drizzle.mdx
@@ -38,26 +38,9 @@ yarn add -D drizzle-kit
 
 </Step>
 
-<Step title="Configure database credentials">
+<Step title="Retrieve database credentials">
 
-Get the database URL:
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token:
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env.local`:
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
@@ -79,9 +62,11 @@ const foo = sqliteTable("foo", {
 
 </Step>
 
-<Step title="Configure Drizzle to work with the LibSQL client">
+<Step title="Connect Drizzle with libSQL">
 
-```ts db.ts
+<CodeGroup>
+
+```ts Node.js / Serverless
 import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
 
@@ -93,11 +78,25 @@ const turso = createClient({
 export const db = drizzle(turso);
 ```
 
+```ts Edge Runtimes
+import { drizzle } from "drizzle-orm/libsql";
+import { createClient } from "@libsql/client/web";
+
+const turso = createClient({
+  url: process.env.TURSO_DATABASE_URL!,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+export const db = drizzle(turso);
+```
+
+</CodeGroup>
+
 </Step>
 
-<Step title="Query your Turso database">
+<Step title="Query">
 
-```tsx App Router
+```ts
 import { db } from "./db";
 
 const result = await db.select().from(foo).all();
@@ -105,7 +104,7 @@ const result = await db.select().from(foo).all();
 
 </Step>
 
-<Step title="Visualize Turso database with Drizzle Studio">
+<Step title="Connect Drizzle Studio">
 
 To preview and manage database data with Drizzle Studio, prepare the Drizzle config file:
 
@@ -125,13 +124,12 @@ export default {
 } satisfies Config;
 ```
 
-Launch Drizzle Studio.
+Launch Drizzle Studio:
 
 <CodeGroup>
 
 ```bash npm
 npx drizzle-kit studio
-
 ```
 
 ```bash pnpm

--- a/sdk/ts/orm/prisma.mdx
+++ b/sdk/ts/orm/prisma.mdx
@@ -36,32 +36,15 @@ yarn add @libsql/client @prisma/adapter-libsql
 
 </Step>
 
-<Step title="Configure database credentials">
+<Step title="Retrieve database credentials">
 
-Get the database URL:
-
-```bash
-turso db show --url <database-name>
-```
-
-Get the database authentication token:
-
-```bash
-turso db tokens create <database-name>
-```
-
-Assign credentials to the environment variables inside `.env.local`:
-
-```bash
-TURSO_DATABASE_URL="..."
-TURSO_AUTH_TOKEN="..."
-```
+<Snippet file="retrieve-database-credentials.mdx" />
 
 </Step>
 
-<Step title="Enable the `driverAdapters` Preview feature flag:">
+<Step title="Enable the `driverAdapters` preview feature flag:">
 
-```js prisma/schema.prisma 3
+```js prisma/schema.prisma
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
@@ -88,7 +71,9 @@ pnpm dlx prisma generate
 
 <Step title="Update your Prisma Client Instance">
 
-```ts
+<CodeGroup>
+
+```ts Node.js / Serverless
 import { PrismaClient } from "@prisma/client";
 import { PrismaLibSQL } from "@prisma/adapter-libsql";
 import { createClient } from "@libsql/client";
@@ -102,9 +87,25 @@ const adapter = new PrismaLibSQL(libsql);
 const prisma = new PrismaClient({ adapter });
 ```
 
+```ts Edge Runtimes
+import { PrismaClient } from "@prisma/client";
+import { PrismaLibSQL } from "@prisma/adapter-libsql";
+import { createClient } from "@libsql/client/web";
+
+const libsql = createClient({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+const adapter = new PrismaLibSQL(libsql);
+const prisma = new PrismaClient({ adapter });
+```
+
+</CodeGroup>
+
 </Step>
 
-<Step title="Query your database">
+<Step title="Query">
 
 ```ts
 const response = await prisma.table_name.findMany();

--- a/sdk/ts/quickstart.mdx
+++ b/sdk/ts/quickstart.mdx
@@ -24,58 +24,13 @@ You will need an existing database to continue. If you don't have one, [create o
 
   <Step title="Install @libsql/client">
 
-First begin by installing the `@libsql/client`:
-
-<CodeGroup>
-
-```bash npm
-npm install @libsql/client
-```
-
-```bash pnpm
-pnpm install @libsql/client
-```
-
-```bash yarn
-yarn add @libsql/client
-```
-
-</CodeGroup>
+<Snippet file="install-libsql-client-ts.mdx" />
 
   </Step>
   <Step title="Initialize a new client">
     Next add your database URL and auth token:
 
-<CodeGroup>
-
-```ts Node.js
-import { createClient } from "@libsql/client";
-
-const client = createClient({
-  url: "libsql://...",
-  authToken: "...",
-});
-```
-
-```ts Edge Runtimes
-import { createClient } from "@libsql/client/web";
-
-const client = createClient({
-  url: "libsql://...",
-  authToken: "...",
-});
-```
-
-</CodeGroup>
-
-<br />
-
-<Info>
-
-You can also connect to a local SQLite file by passing `file:` instead of a URL when using Node.js, [learn
-more](/local-development#sqlite).
-
-</Info>
+<Snippet file="configure-libsql-client-ts.mdx" />
 
   </Step>
   <Step title="Execute a query using SQL">

--- a/sdk/ts/reference.mdx
+++ b/sdk/ts/reference.mdx
@@ -18,58 +18,13 @@ The JavaScript SDK comes with TypeScript bindings and supports environments wher
 
 ## Installing
 
-Install the package in your project using the following command:
-
-<CodeGroup>
-
-```bash npm
-npm install @libsql/client
-```
-
-```bash pnpm
-pnpm install @libsql/client
-```
-
-```bash yarn
-yarn add @libsql/client
-```
-
-</CodeGroup>
+<Snippet file="install-libsql-client-ts.mdx" />
 
 ## Initializing
 
 Import `createClient` to initialize a client that you can use to query your database:
 
-<CodeGroup>
-
-```ts Node.js
-import { createClient } from "@libsql/client";
-
-const client = createClient({
-  url: "libsql://",
-  authToken: "...",
-});
-```
-
-```ts Edge Runtimes
-import { createClient } from "@libsql/client/web";
-
-const client = createClient({
-  url: "libsql://",
-  authToken: "...",
-});
-```
-
-```ts Deno
-import { createClient } from "https://esm.sh/@libsql/client@0.3.5/web";
-
-const client = createClient({
-  url: Deno.env.get("TURSO_API_URL"),
-  authToken: Deno.env.get("TURSO_AUTH_TOKEN"),
-});
-```
-
-</CodeGroup>
+<Snippet file="configure-libsql-client-ts.mdx" />
 
 <br />
 
@@ -382,8 +337,8 @@ You can attach multiple databases to the current connection using the `ATTACH` a
 import { createClient } from "@libsql/client";
 
 const client = createClient({
-  url: process.env.LIBSQL_URL,
-  authToken: process.env.LIBSQL_AUTH_TOKEN,
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
 });
 
 const txn = await db.transaction("read");


### PR DESCRIPTION
This PR cleans up some of our guides to reuse snippets so the same instructions are used for `libsql-client-ts` for Edge/Serverless envs.