### PR TITLE
docs: Named Environment File Causes Drizzle-Kit Studio to throw an error. 

### DIFF
--- a/sdk/ts/orm/drizzle.mdx
+++ b/sdk/ts/orm/drizzle.mdx
@@ -124,7 +124,7 @@ export default {
 } satisfies Config;
 ```
 
-If using a named environment file, ('.env.local' for example) adjust your dotenv.config() accordingly. 
+If using a named environment file, (`.env.local` for example) adjust your `dotenv.config()` accordingly. 
 ```ts
 dotenv.config({ path: `.env.local`, override: true});
 ```

--- a/sdk/ts/orm/drizzle.mdx
+++ b/sdk/ts/orm/drizzle.mdx
@@ -126,7 +126,7 @@ export default {
 
 If using a named environment file, (`.env.local` for example) adjust your `dotenv.config()` accordingly. 
 ```ts
-dotenv.config({ path: `.env.local`, override: true});
+dotenv.config({ path: ".env.local", override: true });
 ```
 
 Launch Drizzle Studio:

--- a/sdk/ts/orm/drizzle.mdx
+++ b/sdk/ts/orm/drizzle.mdx
@@ -124,6 +124,11 @@ export default {
 } satisfies Config;
 ```
 
+If using a named environment file, ('.env.local' for example) adjust your dotenv.config() accordingly. 
+```ts
+dotenv.config({ path: `.env.local`, override: true});
+```
+
 Launch Drizzle Studio:
 
 <CodeGroup>


### PR DESCRIPTION
Minor update to address errors faced by some users copy pasting the drizzle.config.ts snippet directly while using a named environment file.

It's currently 2am and it tripped me up for long enough to check the Discord help channel before realising I had to configure dotenv to look at my .env.local file.  I noticed that at least one other person hit the same errors, so responded to their request and adding an update here. 

Note: the errors from Drizzle complain about url and authToken options being missing, not invalid - which I think is the source of the confusion. I'll get in contact with the Drizzle guys to see if we can get a better error, but the small article amendment is, I think, a good stop-gap for now. 

Thanks!