### PR TITLE
docs: update python link in official sdks

### DIFF
--- a/_snippets/official-sdks.mdx
+++ b/_snippets/official-sdks.mdx
@@ -8,11 +8,7 @@
   <Card title="Go" icon="golang" href="/sdk/go/quickstart">
     Get started with Turso, libSQL and Go.
   </Card>
-  <Card
-    title="Python"
-    icon="python"
-    href="https://github.com/tursodatabase/libsql-experimental-python"
-  >
+  <Card title="Python" icon="python" href="/sdk/python/quickstart">
     Get started with Turso, libSQL and Python.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Since we now have an official Python documentation, the link can be updated to the Python quickstart page instead of the Github repo.