### PR TITLE
docs: update signup phrasing

### DIFF
--- a/cli/introduction.mdx
+++ b/cli/introduction.mdx
@@ -32,7 +32,7 @@ curl -sSfL https://get.tur.so/install.sh | bash
 
 <Step title="Authenticate">
 
-Now signup or login using GitHub:
+Now signup or login:
 
 <CodeGroup>
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -39,7 +39,7 @@ curl -sSfL https://get.tur.so/install.sh | bash
 
 <Step title="Signup to Turso">
 
-The next command will open your browser to sign in with GitHub:
+The next command will open your browser to sign up:
 
 <CodeGroup>
 


### PR DESCRIPTION
The command `turso auth signup` currently allows more options besides Github login.

<img width="425" alt="image" src="https://github.com/tursodatabase/turso-docs/assets/48070464/e2a9a07d-ebbb-4048-bd8e-14cc4998d581">
