### PR TITLE
Fix local-development page and a couple broken links

### DIFF
--- a/features/embedded-replicas/with-render.mdx
+++ b/features/embedded-replicas/with-render.mdx
@@ -12,7 +12,7 @@ Before you start, make sure you:
 
 - [Install the Turso CLI](/cli/installation)
 - [Sign up or login to Turso](/cli/authentication#signup)
-- Have a Render account - [create one](dashboard.render.com/)
+- Have a Render account - [create one](https://dashboard.render.com/)
 
 <Steps>
 

--- a/local-development.mdx
+++ b/local-development.mdx
@@ -168,10 +168,10 @@ Keep in mind that using the Turso hosted database will incur platform costs and 
 
 During development you can easily connect to a SQLite, libSQL, or Turso database using one of the tools below:
 
-* [Beekeeper Studio](https://www.beekeeperstudio.io/db/libsql-client/) &mdash; macOS, Linux, and Windows
-* [Outerbase](https://www.outerbase.com) &mdash; Runs in the browser
-* [TablePlus](https://tableplus.com) &mdash; macOS, Windows, and Linux
-* [Dataflare](https://dataflare.app) &mdash; Paid (with limited free version) macOS app
-* [libSQL Studio](https://github.com/invisal/libsql-studio) - Runs in the browser
+- [Beekeeper Studio](https://www.beekeeperstudio.io/db/libsql-client/) &mdash; macOS, Linux, and Windows
+- [Outerbase](https://www.outerbase.com) &mdash; Runs in the browser
+- [TablePlus](https://tableplus.com) &mdash; macOS, Windows, and Linux
+- [Dataflare](https://dataflare.app) &mdash; Paid (with limited free version) macOS app
+- [libSQL Studio](https://github.com/invisal/libsql-studio) - Runs in the browser
 
 

--- a/local-development.mdx
+++ b/local-development.mdx
@@ -168,7 +168,7 @@ Keep in mind that using the Turso hosted database will incur platform costs and 
 
 During development you can easily connect to a SQLite, libSQL, or Turso database using one of the tools below:
 
-- [Beekeeper Studio](https://www.beekeeperstudio.io/db/libsql-client/) &mdash; macOS, Linux, and Windows
+* [Beekeeper Studio](https://www.beekeeperstudio.io/db/libsql-client/) &mdash; macOS, Linux, and Windows
 * [Outerbase](https://www.outerbase.com) &mdash; Runs in the browser
 * [TablePlus](https://tableplus.com) &mdash; macOS, Windows, and Linux
 * [Dataflare](https://dataflare.app) &mdash; Paid (with limited free version) macOS app

--- a/sdk/ts/reference.mdx
+++ b/sdk/ts/reference.mdx
@@ -351,5 +351,5 @@ const rs = await txn.execute("SELECT * FROM attached.users");
 <Info>
   Make sure to [allow `ATTACH`](/cli/db/config/attach/allow) and create a token
   with the permission to attach a database &mdash; [learn
-  more](/features/attach-databases)
+  more](/features/attach-database)
 </Info>


### PR DESCRIPTION
On the current version of the site, there is a parsing error on the [local-development](https://docs.turso.tech/local-development) page, looks like the issue is related to the first item using a different character in the markdown.

After getting it running locally, I ran `mintlify broken-links` to see if there was anything else to tidy up while I was at it and found the `render` link and the `attach-database` links that were broken. 
- [attach-database](https://docs.turso.tech/sdk/ts/reference#attach)  - the "learn more" in the Info box is currently broken as the link has an "s" on the end
- [render](https://docs.turso.tech/features/embedded-replicas/with-render#prerequisites) - the "Have a render account - create one" link is currently internal so I added "https" to make it external.

There is an additional broken link that I wasn't sure how to fix - on the [platform api](https://docs.turso.tech/features/platform-api) page, the final paragraph mentions "... as well as manage teams ...". I wasn't sure where that "organizations" feature has now moved to or if that text wants updating.