### PR TITLE
Fix: DOCS db:migrate was type twice

### DIFF
--- a/sdk/ts/orm/drizzle.mdx
+++ b/sdk/ts/orm/drizzle.mdx
@@ -134,7 +134,7 @@ export const db = drizzle(turso);
 
 Drizzle can generate and apply database migrations with `drizzle-kit`.
 
-Whenever you make changes to the schema, run `db:migrate`:
+Whenever you make changes to the schema, run `db:generate`:
 
 ```bash
 npm run db:generate


### PR DESCRIPTION
It was two times `db:migrate` , it should be one `db:generate` then  one `db:migrate`