### PR TITLE
Update nuxt.mdx

### DIFF
--- a/sdk/ts/guides/nuxt.mdx
+++ b/sdk/ts/guides/nuxt.mdx
@@ -22,7 +22,24 @@ Before you start, make sure you:
 
 <Step title="Configure database credentials">
 
-<Snippet file="retrieve-database-credentials.mdx" />
+Get the database URL:
+
+```bash
+turso db show --url <database-name>
+```
+
+Get the database authentication token:
+
+```bash
+turso db tokens create <database-name>
+```
+
+Assign credentials to the environment variables inside `.env`.
+
+```bash
+NUXT_TURSO_DATABASE_URL=
+NUXT_TURSO_AUTH_TOKEN=
+```
 
 </Step>
 
@@ -42,7 +59,7 @@ export default defineNuxtConfig({
 <Note>
   Make sure that names of the keys in the `runtimeConfig` object match the names
   of your environment variables. Read more about this
-  [here](https://nitro.unjs.io/guide/configuration#runtime-configuration).
+  [here](https://nuxt.com/docs/guide/going-further/runtime-config).
 </Note>
 
 </Step>


### PR DESCRIPTION
Updated to Nuxt-specific handling and docs.  Nuxt only overrides runtime config props with environment variables that are prefixed with NUXT_.  Referenced Nuxt docs.