### PR TITLE
Update drizzle config file to match latest drizzle version

### DIFF
--- a/sdk/ts/orm/drizzle.mdx
+++ b/sdk/ts/orm/drizzle.mdx
@@ -81,8 +81,7 @@ import type { Config } from "drizzle-kit";
 export default {
   schema: "./db/schema.ts",
   out: "./migrations",
-  dialect: "sqlite",
-  driver: "turso",
+  dialect: "turso",
   dbCredentials: {
     url: process.env.TURSO_DATABASE_URL!,
     authToken: process.env.TURSO_AUTH_TOKEN,


### PR DESCRIPTION
Since drizzle-orm@0.34.0, drizzle supports {dialect: "turso"}, instead of {dialect: "sqlite",  driver: "turso"}. 

See https://orm.drizzle.team/docs/tutorials/drizzle-with-turso#setup-drizzle-config-file