### PR TITLE
feat: expand distance results

### DIFF
--- a/features/ai-and-embeddings.mdx
+++ b/features/ai-and-embeddings.mdx
@@ -133,17 +133,27 @@ ASC;
 
 ### Understanding Distance Results
 
-The `vector_distance_cos` function calculates the cosine distance, which equals 1 - [cosine
-similarity](https://en.wikipedia.org/wiki/Cosine_similarity). Therefore:
+The `vector_distance_cos` function calculates the cosine distance, which is defined at:
 
-- A distance close to 0 (including very small negative numbers like `-6.394e-14`) indicates that the vectors are nearly identical or exactly matching
-- Values closer to 1 indicate that the vectors are dissimilar
-- Typical distance values for non-matching vectors often appear as decimal numbers between 0 and 1
+- Cosine Distance = 1 &mdash; [Cosine Similarity](https://en.wikipedia.org/wiki/Cosine_similarity)
+
+The cosine distance ranges from 0 to 2, where:
+
+- A distance close to 0 indicates that the vectors are nearly identical or exactly matching.
+- A distance close to 1 indicates that the vectors are orthogonal (perpendicular).
+- A distance close to 2 indicates that the vectors are pointing in opposite directions.
 
 <Note>
-  Note: Very small negative numbers close to zero (on the order of `10^-14`) are
-  due to floating-point arithmetic precision and should be interpreted as
-  effectively zero, indicating an exact or near-exact match between vectors.
+  Very small negative numbers close to zero (for example, `-10^-14`) may
+  occasionally appear due to floating-point arithmetic precision. These should
+  be interpreted as effectively zero, indicating an exact or near-exact match
+  between vectors.
+
+```sql
+SELECT vector_distance_cos('[1000]', '[1000]');
+-- Output: -2.0479999918166e-09
+```
+
 </Note>
 
 ### Vector Limitations

--- a/features/ai-and-embeddings.mdx
+++ b/features/ai-and-embeddings.mdx
@@ -27,30 +27,39 @@ Full support for vector search in the Turso platform starts from version `v0.24.
 LibSQL uses the native SQLite BLOB [storage class](https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes) for vector columns. To align with SQLite [affinity rules](https://www.sqlite.org/datatype3.html#determination_of_column_affinity), all type names have two alternatives: one that is easy to type and another with a `_BLOB` suffix that is consistent with affinity rules.
 
 <Info>
-We suggest library authors use type names with the `_BLOB` suffix to make results more generic and universal. For regular applications, developers can choose either alternative, as the type name only serves as a **hint** for SQLite and external extensions.
+  We suggest library authors use type names with the `_BLOB` suffix to make
+  results more generic and universal. For regular applications, developers can
+  choose either alternative, as the type name only serves as a **hint** for
+  SQLite and external extensions.
 </Info>
 
 <Info>
-As LibSQL does not introduce a new storage class, all metadata about vectors is also encoded in the `BLOB` itself. This comes at the cost of a few bytes per row but greatly simplifies the design of the feature.
+  As LibSQL does not introduce a new storage class, all metadata about vectors
+  is also encoded in the `BLOB` itself. This comes at the cost of a few bytes
+  per row but greatly simplifies the design of the feature.
 </Info>
 
 The table below lists six vector types currently supported by LibSQL. Types are listed from more precise and storage-heavy to more compact but less precise alternatives (the number of dimensions in vector $D$ is used to estimate storage requirements for a single vector).
- 
-| Type name                  | Storage (bytes)    | Description |
-| -------------------------- | ------------------ | ----------- |
-| `FLOAT64` \| `F64_BLOB`     | $8D + 1$           | Implementation of [IEEE 754 double precision format](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) for 64-bit floating point numbers |
-| `FLOAT32` \| `F32_BLOB`     | $4D$               | Implementation of [IEEE 754 single precision format](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) for 32-bit floating point numbers |
-| `FLOAT16` \| `F16_BLOB`     | $2D + 1$           | Implementation of [IEEE 754-2008 half precision format](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) for 16-bit floating point numbers |
-| `FLOATB16` \| `FB16_BLOB`   | $2D + 1$           | Implementation of [bfloat16 format](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) for 16-bit floating point numbers |
-| `FLOAT8` \| `F8_BLOB`       | $D + 14$           | LibSQL specific implementation which compresses each vector component to single `u8` byte `b` and reconstruct value from it using simple transformation: $\texttt{shift} + \texttt{alpha} \cdot b$ |
-| `FLOAT1BIT` \| `F1BIT_BLOB` | $\lceil \frac{D}{8} \rceil + 3$ | LibSQL-specific implementation which compresses each vector component down to 1-bit and packs multiple components into a single machine word, achieving a very compact representation |
+
+| Type name                   | Storage (bytes)                 | Description                                                                                                                                                                                        |
+| --------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FLOAT64` \| `F64_BLOB`     | $8D + 1$                        | Implementation of [IEEE 754 double precision format](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) for 64-bit floating point numbers                                       |
+| `FLOAT32` \| `F32_BLOB`     | $4D$                            | Implementation of [IEEE 754 single precision format](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) for 32-bit floating point numbers                                       |
+| `FLOAT16` \| `F16_BLOB`     | $2D + 1$                        | Implementation of [IEEE 754-2008 half precision format](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) for 16-bit floating point numbers                                      |
+| `FLOATB16` \| `FB16_BLOB`   | $2D + 1$                        | Implementation of [bfloat16 format](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) for 16-bit floating point numbers                                                                |
+| `FLOAT8` \| `F8_BLOB`       | $D + 14$                        | LibSQL specific implementation which compresses each vector component to single `u8` byte `b` and reconstruct value from it using simple transformation: $\texttt{shift} + \texttt{alpha} \cdot b$ |
+| `FLOAT1BIT` \| `F1BIT_BLOB` | $\lceil \frac{D}{8} \rceil + 3$ | LibSQL-specific implementation which compresses each vector component down to 1-bit and packs multiple components into a single machine word, achieving a very compact representation              |
 
 <Info>
-For most applications, the `FLOAT32` type should be a good starting point, but you may want to explore more compact options if your table has a large number of rows with vectors.
+  For most applications, the `FLOAT32` type should be a good starting point, but
+  you may want to explore more compact options if your table has a large number
+  of rows with vectors.
 </Info>
 
 <Info>
-While `FLOAT16` and `FLOATB16` use the same amount of storage, they provide different trade-offs between speed and accuracy. Generally, operations over `bfloat16` are faster but come at the expense of lower precision.
+  While `FLOAT16` and `FLOATB16` use the same amount of storage, they provide
+  different trade-offs between speed and accuracy. Generally, operations over
+  `bfloat16` are faster but come at the expense of lower precision.
 </Info>
 
 ### Functions
@@ -59,15 +68,13 @@ To work with vectors, LibSQL provides several functions that operate in the vect
 
 Currently, LibSQL supports the following functions:
 
-| Function name              | Description |
-| -------------------------- | ----------- |
-| `vector64` \| `vector32` \| `vector16` \| `vectorb16` \| `vector8` \| `vector1bit` | Conversion function shiwh accepts valid vector and convert it to the corresponding target type |
-| `vector`     | Alias for `vector32` conversion function |
-| `vector_extract`     | Extraction function which accepts valid vector and return its text representation |
-| `vector_distance_cos`   | Cosine distance (1 - [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity)) function which operates over vector of **same type** with **same dimensionality** |
-| `vector_distance_l2`   | Euclidian distance function which operates over vector of **same type** with **same dimensionality** |
-
-
+| Function name                                                                      | Description                                                                                                                                                                  |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vector64` \| `vector32` \| `vector16` \| `vectorb16` \| `vector8` \| `vector1bit` | Conversion function shiwh accepts valid vector and convert it to the corresponding target type                                                                               |
+| `vector`                                                                           | Alias for `vector32` conversion function                                                                                                                                     |
+| `vector_extract`                                                                   | Extraction function which accepts valid vector and return its text representation                                                                                            |
+| `vector_distance_cos`                                                              | Cosine distance (1 - [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity)) function which operates over vector of **same type** with **same dimensionality** |
+| `vector_distance_l2`                                                               | Euclidian distance function which operates over vector of **same type** with **same dimensionality**                                                                         |
 
 ### Vectors usage
 
@@ -115,21 +122,29 @@ SELECT title,
        vector_extract(embedding),
        vector_distance_cos(embedding, vector32('[0.064, 0.777, 0.661, 0.687]'))
 FROM movies
-ORDER BY 
+ORDER BY
        vector_distance_cos(embedding, vector32('[0.064, 0.777, 0.661, 0.687]'))
 ASC;
 ```
 
-<Note>
-  The `vector_distance_cos` function calculates the cosine **distance**, which
-  equals to 1 - [cosine
-  similarity](https://en.wikipedia.org/wiki/Cosine_similarity). Therefore, a
-  smaller distance indicates that the vectors are closer to each other.
-</Note>
-
 </Step>
 
 </Steps>
+
+### Understanding Distance Results
+
+The `vector_distance_cos` function calculates the cosine distance, which equals 1 - [cosine
+similarity](https://en.wikipedia.org/wiki/Cosine_similarity). Therefore:
+
+- A distance close to 0 (including very small negative numbers like `-6.394e-14`) indicates that the vectors are nearly identical or exactly matching
+- Values closer to 1 indicate that the vectors are dissimilar
+- Typical distance values for non-matching vectors often appear as decimal numbers between 0 and 1
+
+<Note>
+  Note: Very small negative numbers close to zero (on the order of `10^-14`) are
+  due to floating-point arithmetic precision and should be interpreted as
+  effectively zero, indicating an exact or near-exact match between vectors.
+</Note>
 
 ### Vector Limitations
 
@@ -140,13 +155,15 @@ ASC;
 
 Nearest neighbors (NN) queries are popular for various AI-powered applications ([RAG](https://en.wikipedia.org/wiki/Retrieval-augmented_generation) uses NN queries to extract relevant information, and recommendation engines can suggest items based on embedding similarity).
 
-LibSQL implements [DiskANN](https://turso.tech/blog/approximate-nearest-neighbor-search-with-diskann-in-libsql) algorithm in order to speed up approximate neareast neighbors queries for tables with vector colums. 
+LibSQL implements [DiskANN](https://turso.tech/blog/approximate-nearest-neighbor-search-with-diskann-in-libsql) algorithm in order to speed up approximate neareast neighbors queries for tables with vector colums.
 
 <Note>
-The DiskANN algorithm trades search accuracy for speed, so LibSQL queries may return slightly suboptimal neighbors for tables with a large number of rows.
+  The DiskANN algorithm trades search accuracy for speed, so LibSQL queries may
+  return slightly suboptimal neighbors for tables with a large number of rows.
 </Note>
 
 ### Vector Index
+
 LibSQL introduces a custom index type that helps speed up nearest neighbors queries against a fixed distance function (cosine similarity by default).
 
 From a syntax perspective, the vector index differs from ordinary application-defined B-Tree indices in that it must wrap the vector column into a `libsql_vector_idx` marker function like this
@@ -156,7 +173,8 @@ CREATE INDEX movies_idx ON movies (libsql_vector_idx(embedding));
 ```
 
 <Note>
-Vector index works only for column with one of the vector types described above
+  Vector index works only for column with one of the vector types described
+  above
 </Note>
 
 The vector index is fully integrated into the LibSQL core, so it inherits all operations and most features from ordinary indices:
@@ -166,8 +184,9 @@ The vector index is fully integrated into the LibSQL core, so it inherits all op
 - You can rebuild index from scratch using `REINDEX movies_idx` command
 - You can drop index with `DROP INDEX movies_idx` command
 - You can create [partial](https://www.sqlite.org/partialindex.html) vector index with a custom filtering rule:
+
 ```sql
-CREATE INDEX movies_idx ON movies (libsql_vector_idx(embedding)) 
+CREATE INDEX movies_idx ON movies (libsql_vector_idx(embedding))
 WHERE year >= 2000;
 ```
 
@@ -180,26 +199,28 @@ In order for table-valued function to work query vector **must** have same vecto
 ### Settings
 
 LibSQL vector index optionally can accept settings which must be specified as a variadic parameters of the `libsql_vector_idx` function as a strings in the format `key=value`:
+
 ```sql
-CREATE INDEX movies_idx 
+CREATE INDEX movies_idx
 ON movies(libsql_vector_idx(embedding, 'metric=l2', 'compress_neighbors=float8'));
 ```
 
 At the moment LibSQL supports following settings:
 
-| Setting key                | Value type       | Description |
-| -------------------------- | ---------------- | ----------- |
-| `metric`                   | `cosine` \| `l2`  | Which distance function to use for building index. <br/> Default: `cosine` |
-| `max_neighbors`            | positive integer | How many neighbors to store for every node in the DiskANN graph. The lower the setting -- the less storage index will use in exchange to search precision. <br/> Default: $3 \sqrt{D}$ where $D$ -- dimensionality of vector column |
-| `compress_neighbors`       | `float1bit`\|`float8`\|<br/>`float16`\|`floatb16`\|<br/>`float32` | Which vector type must be used to store neighbors for every node in the DiskANN graph. The more compact vector type is used for neighbors -- the less storage index will use in exchange to search precision. <br/> Default: **no comperssion** (neighbors has same type as base table)   | 
-| `alpha`       | positive float $\geq 1$ | "Density" parameter of general sparse neighborhood graph build during DiskANN algorithm. The lower parameter -- the more sparse is DiskANN graph which can speed up query speed in exchange to lower search precision. <br/>Default: `1.2`  |
-| `search_l`       | positive integer | Setting which limits amount of neighbors visited during vector search. The lower the setting -- the faster will be search query in exchange to search precision. <br/>Default: `200` |
-| `insert_l`       | positive integer | Setting which limits amount of neighbors visited during vector insert. The lower the setting -- the faster will be insert query in exchange to DiskANN graph navigability properties. <br/>Default: `70` |
+| Setting key          | Value type                                                        | Description                                                                                                                                                                                                                                                                             |
+| -------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metric`             | `cosine` \| `l2`                                                  | Which distance function to use for building index. <br/> Default: `cosine`                                                                                                                                                                                                              |
+| `max_neighbors`      | positive integer                                                  | How many neighbors to store for every node in the DiskANN graph. The lower the setting -- the less storage index will use in exchange to search precision. <br/> Default: $3 \sqrt{D}$ where $D$ -- dimensionality of vector column                                                     |
+| `compress_neighbors` | `float1bit`\|`float8`\|<br/>`float16`\|`floatb16`\|<br/>`float32` | Which vector type must be used to store neighbors for every node in the DiskANN graph. The more compact vector type is used for neighbors -- the less storage index will use in exchange to search precision. <br/> Default: **no comperssion** (neighbors has same type as base table) |
+| `alpha`              | positive float $\geq 1$                                           | "Density" parameter of general sparse neighborhood graph build during DiskANN algorithm. The lower parameter -- the more sparse is DiskANN graph which can speed up query speed in exchange to lower search precision. <br/>Default: `1.2`                                              |
+| `search_l`           | positive integer                                                  | Setting which limits amount of neighbors visited during vector search. The lower the setting -- the faster will be search query in exchange to search precision. <br/>Default: `200`                                                                                                    |
+| `insert_l`           | positive integer                                                  | Setting which limits amount of neighbors visited during vector insert. The lower the setting -- the faster will be insert query in exchange to DiskANN graph navigability properties. <br/>Default: `70`                                                                                |
 
 <Note>
-Vector index for column of type `T1` with `max_neighbors=M` and `compress_neighbors=T2` will approximately use $\texttt{N} (Storage(\texttt{T1}) + \texttt{M} \cdot Storage(\texttt{T2}))$ storage bytes for `N` rows.
+  Vector index for column of type `T1` with `max_neighbors=M` and
+  `compress_neighbors=T2` will approximately use $\texttt{N} (Storage(\texttt
+  {T1}) + \texttt{M} \cdot Storage(\texttt{T2}))$ storage bytes for `N` rows.
 </Note>
-
 
 ### Index usage
 
@@ -258,7 +279,7 @@ This creates an index optimized for vector similarity searches on the `embedding
 <Step title="Query the indexed table">
 
 ```sql
-SELECT title, year 
+SELECT title, year
 FROM vector_top_k('movies_idx', vector32('[0.064, 0.777, 0.661, 0.687]'), 3)
 JOIN movies ON movies.rowid = id
 WHERE year >= 2020;
@@ -273,4 +294,3 @@ This query uses the `vector_top_k` [table-valued function](https://www.sqlite.or
 ### Index limitations
 
 - Vector index works only for tables **with** `ROWID` or with singular `PRIMARY KEY`. Composite `PRIMARY KEY` without `ROWID` is not supported
-


### PR DESCRIPTION
```md
### Understanding Distance Results

The `vector_distance_cos` function calculates the cosine distance, which equals 1 - [cosine
similarity](https://en.wikipedia.org/wiki/Cosine_similarity). Therefore:

- A distance close to 0 (including very small negative numbers like `-6.394e-14`) indicates that the vectors are nearly identical or exactly matching
- Values closer to 1 indicate that the vectors are dissimilar
- Typical distance values for non-matching vectors often appear as decimal numbers between 0 and 1

OR

<Note>
  Note: Very small negative numbers close to zero (on the order of `10^-14`) are
  due to floating-point arithmetic precision and should be interpreted as
  effectively zero, indicating an exact or near-exact match between vectors.
</Note>
```