### PR TITLE
Spelling of syncInterval

### DIFF
--- a/sdk/php/quickstart.mdx
+++ b/sdk/php/quickstart.mdx
@@ -45,7 +45,7 @@ In this PHP quickstart we will learn how to:
           path: 'test.db',
           url: getenv('TURSO_URL'),
           authToken: getenv('TURSO_AUTH_TOKEN')
-          syncIterval: 100 // Sync every second
+          syncInterval: 100 // Sync every second
       );
       $conn = $db->connect();
       ```


### PR DESCRIPTION
Fix spelling of `syncInterval` parameter.