### PR TITLE
Add deno option to the install snippet

### DIFF
--- a/_snippets/install-libsql-client-ts.mdx
+++ b/_snippets/install-libsql-client-ts.mdx
@@ -14,4 +14,8 @@ pnpm install @libsql/client
 yarn add @libsql/client
 ```
 
+```bash deno
+deno add npm:@libsql/client
+```
+
 </CodeGroup>


### PR DESCRIPTION
As featured on this page `https://docs.turso.tech/sdk/ts/quickstart`, the @libsql/client package can now be installed from NPM using Deno as a package manager.

Since using Deno is already present in some examples in the docs, it would be nice to include this option in install snippet that gets used around the site.

This PR adds another tab option to the snippet:

```
deno add npm:@libsql/client
```

This command has been tested and validated using Deno v2.1.2