### PR TITLE
Update reference.mdx for Batch Usage transaction example

### DIFF
--- a/sdk/ts/reference.mdx
+++ b/sdk/ts/reference.mdx
@@ -265,7 +265,7 @@ try {
 ```
 
 ```ts Batch Usage
-let transaction: typeof client.transaction | null = null
+let transaction: Transaction | null = null
 
 try {
   const records = [

--- a/sdk/ts/reference.mdx
+++ b/sdk/ts/reference.mdx
@@ -265,6 +265,8 @@ try {
 ```
 
 ```ts Batch Usage
+let transaction: typeof client.transaction | null = null
+
 try {
   const records = [
     { name: "Alice", age: 30 },
@@ -272,7 +274,7 @@ try {
     { name: "Charlie", age: 35 },
   ];
 
-  const transaction = await client.transaction("write");
+  transaction = await client.transaction("write");
 
   for (const record of records) {
     await transaction.execute({
@@ -284,7 +286,7 @@ try {
   await transaction.commit();
 } catch (e) {
   console.error(e);
-  await transaction.rollback();
+  if (transaction) await transaction.rollback();
 }
 ```
 


### PR DESCRIPTION
`transaction` is used outside the try block. If one of execute commands would fail, transaction is not defined in catch, hence rollback would not happen