### PR TITLE
Add Missing Database Migration Step in Prisma ORM Integration

### DIFF
--- a/sdk/ts/orm/prisma.mdx
+++ b/sdk/ts/orm/prisma.mdx
@@ -49,6 +49,11 @@ generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
 }
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
 ```
 
 </Step>
@@ -58,11 +63,11 @@ generator client {
 <CodeGroup>
 
 ```sh npm
-npx prisma generate
+npx prisma migrate dev --name init
 ```
 
 ```sh pnpm
-pnpm dlx prisma generate
+pnpm dlx prisma migrate dev --name init
 ```
 
 </CodeGroup>
@@ -102,6 +107,22 @@ const prisma = new PrismaClient({ adapter });
 ```
 
 </CodeGroup>
+
+</Step>
+
+<Step title="Database Migrations">
+
+Prisma Migrate and Introspection workflows are currently not supported when working with Turso &mdash; [learn more](https://www.prisma.io/docs/orm/overview/databases/turso#how-to-manage-schema-changes).
+
+```bash
+turso db shell turso-prisma-db < ./prisma/migrations/20230922132717_init/migration.sql
+```
+
+<Info>
+
+Replace `20230922132717_init` with the name of your migration.
+
+</Info>
 
 </Step>
 

--- a/sdk/ts/orm/prisma.mdx
+++ b/sdk/ts/orm/prisma.mdx
@@ -63,11 +63,11 @@ datasource db {
 <CodeGroup>
 
 ```sh npm
-npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 ```sh pnpm
-pnpm dlx prisma migrate dev --name init
+pnpm dlx prisma generate
 ```
 
 </CodeGroup>
@@ -114,13 +114,29 @@ const prisma = new PrismaClient({ adapter });
 
 Prisma Migrate and Introspection workflows are currently not supported when working with Turso &mdash; [learn more](https://www.prisma.io/docs/orm/overview/databases/turso#how-to-manage-schema-changes).
 
+First, generate a migration file using prisma migrate dev against a local SQLite database
+
+<CodeGroup>
+
+```sh npm
+npx prisma migrate dev --name init
+```
+
+```sh pnpm
+pnpm dlx prisma migrate dev --name init
+```
+
+</CodeGroup>
+
+Then, apply the migration to your Turso database using the Turso's CLI
+
 ```bash
 turso db shell turso-prisma-db < ./prisma/migrations/20230922132717_init/migration.sql
 ```
 
 <Info>
 
-Replace `20230922132717_init` with the name of your migration.
+Replace `20230922132717_init` with the name of your migration created from the `npx prisma migrate dev` command.
 
 </Info>
 


### PR DESCRIPTION
Integrating the Turso database with Prisma ORM requires an additional setup step. I initially faced challenges with running migrations after completing the setup. After reviewing the [Prisma Documentation](https://www.prisma.io/docs/orm/overview/databases/turso), I identified the solution and implemented the necessary steps for a seamless migration process. Adding these steps will help others encountering the same issue.