### PR TITLE
fix: broken link in scale-to-zero.mdx

### DIFF
--- a/features/scale-to-zero.mdx
+++ b/features/scale-to-zero.mdx
@@ -5,7 +5,7 @@ title: Scale to Zero
 <Warning>
   This feature is now deprecated for all new users. Existing free users will be
   moved from Fly to AWS, and receive no cold starts by default &mdash; [read the
-  announcement](/upcoming-changes-to-the-turso-platform-and-roadmap)
+  announcement](https://turso.tech/blog/upcoming-changes-to-the-turso-platform-and-roadmap)
 </Warning>
 
 For free Starter Plan users, Turso dynamically scales databases down to zero after an hour of no activity. This behaviour is how we can continue to provide hundreds of databases on the free plan.


### PR DESCRIPTION
Update announcement link to point to blog; previous link was redirecting to docs home page instead of the announcement.