### PR TITLE
Quickstart: Specify that Windows requires WSL

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -26,7 +26,7 @@ brew install tursodatabase/tap/turso
 curl -sSfL https://get.tur.so/install.sh | bash
 ```
 
-```bash Windows
+```bash Windows (WSL)
 curl -sSfL https://get.tur.so/install.sh | bash
 ```
 


### PR DESCRIPTION
The [quickstart](https://docs.turso.tech/quickstart) currently does not mention that the CLI on Windows only works in WSL. Hence, I have added (WSL) there. This is identical to the wording in the [introduction to the CLI](https://docs.turso.tech/cli/introduction) (see screenshot).

<img width="784" alt="Bildschirmfoto 2025-04-04 um 13 33 14" src="https://github.com/user-attachments/assets/33ddf6ad-aeb2-47f6-bc83-809852569ba4" />

Thought: It is explained in more detail in the [installation of the CLI](https://docs.turso.tech/cli/installation), maybe it would even be better to link there. But I am not sure.