### PR TITLE
Document Reset Prepared Statement

### DIFF
--- a/sdk/rust/reference.mdx
+++ b/sdk/rust/reference.mdx
@@ -185,6 +185,12 @@ You can prepare a cached statement using `prepare()` and then execute it with `q
 let stmt = db_conn.prepare("SELECT * FROM users").await?;
 
 db_conn.query(&stmt, [&1]).await?;
+
+// reset state when calling with different parameters
+stmt.reset();
+
+db_conn.query(&stmt, [&2]).await?;
+
 ```
 
 ## Placeholders

--- a/sdk/rust/reference.mdx
+++ b/sdk/rust/reference.mdx
@@ -182,7 +182,7 @@ conn.execute("SELECT * FROM users WHERE id = ?1", [1]).await?;
 You can prepare a cached statement using `prepare()` and then execute it with `query()`:
 
 ```rust
-let stmt = db_conn.prepare("SELECT * FROM users").await?;
+let mut stmt = db_conn.prepare("SELECT * FROM users").await?;
 
 db_conn.query(&stmt, [&1]).await?;
 


### PR DESCRIPTION
For sql newbies like myself its not obvious that prepared statements need to be reset when calling with different parameters.