### PR TITLE
fix(openapi.json): duplicated operationId "transferGroup"

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -834,7 +834,7 @@
       "post": {
         "summary": "Unarchive Group",
         "description": "Unarchive a group that has been archived due to inactivity.",
-        "operationId": "transferGroup",
+        "operationId": "unarchiveGroup",
         "parameters": [
           {
             "$ref": "#/components/parameters/organizationSlug"


### PR DESCRIPTION
`"operationId": "transferGroup"` is duplicated at path `/v1/organizations/{organizationSlug}/groups/{groupName}/unarchive` (line 837)

Probably should have been `unarchiveGroup` or something.

This issue shows during client generation and is easily reproducible with:

```
docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate -i https://raw.githubusercontent.com/tursodatabase/turso-docs/refs/heads/main/api-reference/openapi.json -g go -o /local/ 
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 0
Errors: 
        -attribute paths.'/v1/organizations/{organizationSlug}/groups/{groupName}/unarchive'(post).operationId is repeated

        at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:717)
        at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:744)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:527)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```