### PR TITLE
Refactor: Remove 'gem' keyword from libsql_activerecord in Gemfile

### DIFF
--- a/sdk/activerecord/guides/rails.mdx
+++ b/sdk/activerecord/guides/rails.mdx
@@ -21,7 +21,7 @@ Before you start, make sure you:
 Add the following to your Gemfile:
 
 ```ruby
-gem 'libsql_activerecord'
+gem libsql_activerecord
 ```
 
 Then run:


### PR DESCRIPTION
Remove unnecessary single quotes of command gem -> gem libsql_activerecord.