### PR TITLE
Use `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` in step 3 `Connect` in go sdk docs

### DIFF
--- a/sdk/go/quickstart.mdx
+++ b/sdk/go/quickstart.mdx
@@ -74,8 +74,8 @@ Now connect to your local or remote database using the libSQL connector:
 
     func main() {
         dbName := "local.db"
-        primaryUrl := "libsql://[DATABASE].turso.io"
-        authToken := "..."
+        primaryUrl := "[TURSO_DATABASE_URL]"
+        authToken := "[TURSO_AUTH_TOKEN]"
 
         dir, err := os.MkdirTemp("", "libsql-*")
         if err != nil {
@@ -141,7 +141,7 @@ Now connect to your local or remote database using the libSQL connector:
     )
 
     func main() {
-      url := "libsql://[DATABASE].turso.io?authToken=[TOKEN]"
+      url := "[TURSO_DATABASE_URL]?authToken=[TURSO_AUTH_TOKEN]"
 
       db, err := sql.Open("libsql", url)
       if err != nil {


### PR DESCRIPTION
Use `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` in step 3 `Connect` in go sdk docs since those env variables are defined in step 1 `Retrieve database credentials`