### PR TITLE
docs(sdk): add Capacitor as community SDK

### DIFF
--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -32,6 +32,22 @@ These SDKs are community-driven and don't come with official Turso support.
 
 <Card
   horizontal
+  title="Capacitor"
+  icon={
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+      <path fill="#53b9ff" d="M19.93 27.059.156 46.859l30.496 30.59L0 108.191l19.715 19.813L50.43 97.25l30.547 30.531 19.777-19.8Zm0 0"/>
+      <path fill="#119eff" d="M70.258 77.45 50.43 97.25l30.547 30.531 19.777-19.8Zm0 0"/>
+      <path fill-opacity=".2" d="M70.258 77.45 50.43 97.25l7.633 7.59Zm0 0"/>
+      <path fill="#53b9ff" d="M97.285 50.492 128 19.738 108.215 0 77.512 30.691 46.957.156 27.184 19.957l80.82 80.922 19.777-19.8Zm0 0"/>
+      <path fill="#119eff" d="m57.68 50.492 19.828-19.8L46.957.155 27.184 19.957Zm0 0"/>
+      <path fill-opacity=".2" d="m57.68 50.492 19.828-19.8-7.633-7.594Zm0 0"/>
+  </svg>
+  }
+  href="https://capawesome.io/plugins/libsql"
+/>
+
+<Card
+  horizontal
   title="React Native / OP-SQLite"
   icon="react"
   href="https://op-engineering.github.io/op-sqlite/"


### PR DESCRIPTION
We have created a libSQL SDK for [Capacitor](https://capacitorjs.com/). We would love to list this SDK under the Community SDKs so that it is recognized by the community. Let me know if you want me to change anything.