### PR TITLE
update Prisma client creation docs

### DIFF
--- a/sdk/ts/orm/prisma.mdx
+++ b/sdk/ts/orm/prisma.mdx
@@ -81,29 +81,24 @@ pnpm dlx prisma generate
 ```ts Node.js / Serverless
 import { PrismaClient } from "@prisma/client";
 import { PrismaLibSQL } from "@prisma/adapter-libsql";
-import { createClient } from "@libsql/client";
 
-const libsql = createClient({
+const adapter = new PrismaLibSQL({
   url: process.env.TURSO_DATABASE_URL,
   authToken: process.env.TURSO_AUTH_TOKEN,
-});
-
-const adapter = new PrismaLibSQL(libsql);
-const prisma = new PrismaClient({ adapter });
+})
+const prisma = new PrismaClient({ adapter })
 ```
 
 ```ts Edge Runtimes
 import { PrismaClient } from "@prisma/client";
-import { PrismaLibSQL } from "@prisma/adapter-libsql";
+import { PrismaLibSQL } from "@prisma/adapter-libsql/web";
 import { createClient } from "@libsql/client/web";
 
-const libsql = createClient({
+const adapter = new PrismaLibSQL({
   url: process.env.TURSO_DATABASE_URL,
   authToken: process.env.TURSO_AUTH_TOKEN,
-});
-
-const adapter = new PrismaLibSQL(libsql);
-const prisma = new PrismaClient({ adapter });
+})
+const prisma = new PrismaClient({ adapter })
 ```
 
 </CodeGroup>

--- a/sdk/ts/orm/prisma.mdx
+++ b/sdk/ts/orm/prisma.mdx
@@ -91,7 +91,7 @@ const prisma = new PrismaClient({ adapter })
 
 ```ts Edge Runtimes
 import { PrismaClient } from "@prisma/client";
-import { PrismaLibSQL } from "@prisma/adapter-libsql/web";
+import { PrismaLibSQL } from "@prisma/adapter-libsql";
 import { createClient } from "@libsql/client/web";
 
 const adapter = new PrismaLibSQL({

--- a/sdk/ts/orm/prisma.mdx
+++ b/sdk/ts/orm/prisma.mdx
@@ -92,7 +92,6 @@ const prisma = new PrismaClient({ adapter })
 ```ts Edge Runtimes
 import { PrismaClient } from "@prisma/client";
 import { PrismaLibSQL } from "@prisma/adapter-libsql";
-import { createClient } from "@libsql/client/web";
 
 const adapter = new PrismaLibSQL({
   url: process.env.TURSO_DATABASE_URL,


### PR DESCRIPTION
referring to: https://github.com/prisma/prisma/issues/27543

The current documentation for connecting Prisma to Turso/libsql is no longer correct. To update related section in the docs to reflect latest method.