### PR TITLE
docs(prisma): Remove driverAdapters preview feature flag

### DIFF
--- a/sdk/ts/orm/prisma.mdx
+++ b/sdk/ts/orm/prisma.mdx
@@ -56,7 +56,7 @@ datasource db {
 ```
 
 <Note>
-For Prisma versions 5.x, you may need to add `previewFeatures = ["driverAdapters"]` to the generator block. This is no longer required in Prisma 6.x and later.
+For Prisma versions before 6.16.0, you need to add `previewFeatures = ["driverAdapters"]` to the generator block. This preview feature was promoted to General Availability in Prisma 6.16.0 and is no longer required.
 </Note>
 
 </Step>


### PR DESCRIPTION
# Prisma Documentation Update

## Summary

Updates Prisma documentation to reflect that the `driverAdapters` preview feature flag is no longer required in Prisma 6.16.0 and later when using Turso with `@prisma/adapter-libsql`.

## Changes

- Removed `previewFeatures = ["driverAdapters"]` from the example Prisma schema
- Updated the step title from "Enable the driverAdapters preview feature flag" to "Configure your Prisma schema"
- Added a note explaining that this flag was required before Prisma 6.16.0, but was promoted to General Availability in that version

## Context

The `driverAdapters` feature was promoted from preview to General Availability in Prisma 6.16.0, so it no longer needs to be explicitly enabled as a preview feature. This change ensures the documentation reflects current best practices and doesn't require users to add unnecessary configuration flags.

## References

- [[Prisma 6.16.0 Release](https://github.com/prisma/prisma/releases/tag/6.16.0)](https://github.com/prisma/prisma/releases/tag/6.16.0) - Driver Adapters GA announcement
- [[Database Drivers Documentation](https://www.prisma.io/docs/orm/overview/databases/database-drivers)](https://www.prisma.io/docs/orm/overview/databases/database-drivers)