### PR TITLE
Add AgentFS documentation section

### DIFF
--- a/agentfs/introduction.mdx
+++ b/agentfs/introduction.mdx
@@ -1,0 +1,167 @@
+---
+title: AgentFS Introduction
+description: A filesystem and state management SDK for AI agents, built on Turso
+sidebarTitle: Overview
+---
+
+AgentFS is a specialized filesystem and state management SDK designed for AI agents. It provides a complete, queryable, and portable solution for managing agent state, files, and interactions—all powered by Turso's embedded database technology.
+
+## Why AgentFS?
+
+Building reliable AI agents requires solving fundamental challenges:
+
+- **State Management**: Agents need persistent memory across sessions
+- **Auditability**: Every action must be traceable for debugging and compliance
+- **Reproducibility**: Agent states must be snapshottable and restorable
+- **Simplicity**: Complex distributed systems shouldn't be required for agent development
+
+AgentFS solves these challenges with a single, portable database file that contains your entire agent runtime.
+
+## Key Features
+
+<CardGroup cols={2}>
+  <Card title="Virtual Filesystem" icon="folder">
+    POSIX-like file and directory operations for agent data management
+  </Card>
+  <Card title="Key-Value Store" icon="database">
+    Fast, typed storage for agent state and configuration
+  </Card>
+  <Card title="Tool Call Tracking" icon="list-check">
+    Automatic audit logging of all agent tool invocations
+  </Card>
+  <Card title="Single File Storage" icon="file">
+    Entire agent runtime in one portable Turso database
+  </Card>
+</CardGroup>
+
+## Core Capabilities
+
+### 🗄️ Unified Storage
+Everything your agent needs—files, state, history—stored in a single database file. No complex infrastructure, just one file you can query, backup, or move.
+
+### 🔍 Built-in Auditability
+Every filesystem operation, state change, and tool call is automatically recorded. Query your agent's behavior with SQL:
+
+```sql
+-- Find all web searches performed by the agent
+SELECT * FROM toolcalls
+WHERE name = 'web_search'
+ORDER BY timestamp DESC;
+
+-- Analyze file modifications
+SELECT * FROM events
+WHERE type = 'file_write'
+AND timestamp > datetime('now', '-1 hour');
+```
+
+### 🔄 State Reproducibility
+Snapshot agent states at any point and restore them later. Perfect for:
+- Debugging complex agent behaviors
+- Testing different execution paths
+- Creating checkpoints in long-running workflows
+
+### 📦 Portability
+Move your entire agent between environments with a single file. Development to production, cloud to edge—your agent's complete state travels with it.
+
+## Architecture
+
+AgentFS provides three main interfaces:
+
+```mermaid
+graph LR
+    A[AI Agent] --> B[AgentFS SDK]
+    B --> C[Filesystem API]
+    B --> D[Key-Value API]
+    B --> E[Tool Call API]
+    C --> F[Turso Database]
+    D --> F
+    E --> F
+```
+
+All operations are atomic and transactional, ensuring data consistency even during failures.
+
+## Quick Example
+
+```typescript
+import { AgentFS } from 'agentfs-sdk';
+
+// Open or create an agent filesystem
+const agent = await AgentFS.open(
+  './my-agent.db'
+);
+
+// Store agent configuration
+await agent.kv.set('agent:config', {
+  model: 'gpt-4',
+  temperature: 0.7,
+  maxTokens: 2000
+});
+
+// Write generated content
+await agent.fs.writeFile(
+  '/outputs/report.md',
+  reportContent
+);
+
+// Track tool usage
+await agent.tools.record(
+  'generate_report',
+  startTime,
+  endTime,
+  { topic: 'Q4 Analysis' },
+  { success: true, pages: 15 }
+);
+
+// Query the agent's work
+const recentFiles = await agent.fs.readdir('/outputs');
+const toolHistory = await agent.tools.list({ limit: 10 });
+```
+
+## Use Cases
+
+<CardGroup cols={2}>
+  <Card title="Development & Testing" icon="code">
+    Develop agents locally with full state persistence and debugging capabilities
+  </Card>
+  <Card title="Production Deployment" icon="rocket">
+    Deploy agents with built-in logging, monitoring, and state management
+  </Card>
+  <Card title="Compliance & Auditing" icon="shield">
+    Track every agent action for regulatory compliance and accountability
+  </Card>
+  <Card title="Multi-Agent Systems" icon="users">
+    Share state between agents or maintain isolation with separate databases
+  </Card>
+</CardGroup>
+
+## Getting Started
+
+Ready to build more reliable AI agents? Start with our quickstart guide:
+
+<Card title="AgentFS Quickstart" icon="play" href="/agentfs/quickstart">
+  Set up AgentFS and build your first stateful agent in minutes
+</Card>
+
+## Available SDKs
+
+<CardGroup cols={3}>
+  <Card title="TypeScript" icon="js" href="/agentfs/sdk/typescript">
+    Full-featured SDK for Node.js and browser environments
+  </Card>
+  <Card title="Rust" icon="rust" href="/agentfs/sdk/rust">
+    High-performance native SDK with async support
+  </Card>
+  <Card title="Python" icon="python">
+    Coming soon - Python SDK for data science and ML workflows
+  </Card>
+</CardGroup>
+
+## Learn More
+
+- [Blog: Introducing AgentFS](https://turso.tech/blog/agentfs) - Deep dive into why we built AgentFS
+- [GitHub Repository](https://github.com/tursodatabase/agentfs) - Source code and examples
+- [API Reference](/agentfs/api-reference) - Complete API documentation
+
+<Warning>
+AgentFS is currently in ALPHA. We recommend using it for development and testing only. The API may change as we gather feedback from the community.
+</Warning>

--- a/agentfs/quickstart.mdx
+++ b/agentfs/quickstart.mdx
@@ -1,0 +1,400 @@
+---
+title: AgentFS Quickstart
+description: Build your first stateful AI agent with AgentFS in 5 minutes
+sidebarTitle: Quickstart
+---
+
+Get up and running with AgentFS to build stateful, auditable AI agents in just a few minutes.
+
+## Prerequisites
+
+- Node.js 18+ or Rust 1.70+
+- Basic familiarity with async/await programming
+- An AI/LLM API key (optional, for agent examples)
+
+## Installation
+
+<Tabs>
+  <Tab title="TypeScript/JavaScript">
+    ```bash
+    npm install agentfs-sdk
+    ```
+  </Tab>
+  <Tab title="Rust">
+    ```toml
+    [dependencies]
+    agentfs = "0.1"
+    tokio = { version = "1", features = ["full"] }
+    ```
+  </Tab>
+</Tabs>
+
+## Create Your First Agent
+
+Let's build a simple agent that maintains conversation history and generates files.
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript
+    import { AgentFS } from 'agentfs-sdk';
+
+    // Initialize AgentFS with a local database
+    const agent = await AgentFS.open(
+      './my-agent.db'
+    );
+
+    // Store agent configuration
+    await agent.kv.set('agent:id', 'assistant-001');
+    await agent.kv.set(
+      'agent:created',
+      new Date().toISOString()
+    );
+
+    // Create a conversation history
+    const conversations = [];
+
+    async function addMessage(role: string, content: string) {
+      const message = {
+        role,
+        content,
+        timestamp: Date.now()
+      };
+
+      conversations.push(message);
+
+      // Persist to AgentFS
+      await agent.kv.set('conversations', conversations);
+
+      // Also save as a file for easy access
+      const filename = `/conversations/${Date.now()}.json`;
+      await agent.fs.writeFile(
+        filename,
+        JSON.stringify(message, null, 2)
+      );
+
+      // Track this as a tool call
+      await agent.tools.record(
+        'save_message',
+        Date.now() / 1000,
+        Date.now() / 1000 + 0.1,
+        { role, contentLength: content.length },
+        { saved: true, filename }
+      );
+    }
+
+    // Example usage
+    await addMessage(
+      'user',
+      'Hello, can you help me with a task?'
+    );
+    await addMessage(
+      'assistant',
+      'Of course! I'd be happy to help.'
+    );
+
+    // Retrieve conversation history
+    const history = await agent.kv.get('conversations');
+    console.log('Conversation history:', history);
+
+    // List all conversation files
+    const files = await agent.fs.readdir('/conversations');
+    console.log('Saved conversations:', files);
+    ```
+  </Tab>
+  <Tab title="Rust">
+    ```rust
+    use agentfs::AgentFS;
+    use serde::{Serialize, Deserialize};
+    use chrono::Utc;
+
+    #[derive(Serialize, Deserialize)]
+    struct Message {
+        role: String,
+        content: String,
+        timestamp: i64,
+    }
+
+    #[tokio::main]
+    async fn main() -> Result<(),
+      Box<dyn std::error::Error>> {
+        // Initialize AgentFS with a local database
+        let agent = AgentFS::open(
+          "./my-agent.db"
+        ).await?;
+
+        // Store agent configuration
+        agent.kv.set("agent:id", "assistant-001").await?;
+        agent.kv.set(
+          "agent:created",
+          Utc::now().to_rfc3339()
+        ).await?;
+
+        // Create a message
+        let message = Message {
+            role: "user".to_string(),
+            content: "Hello, can you help me with a task?"
+              .to_string(),
+            timestamp: Utc::now().timestamp_millis(),
+        };
+
+        // Save message to filesystem
+        let filename = format!(
+          "/conversations/{}.json",
+          message.timestamp
+        );
+        let json = serde_json::to_string_pretty(
+          &message
+        )?;
+        agent.fs.write_file(
+          &filename,
+          json.as_bytes()
+        ).await?;
+
+        // Track as tool call
+        agent.tools.record(
+            "save_message",
+            Utc::now().timestamp() as f64,
+            Utc::now().timestamp() as f64 + 0.1,
+            serde_json::json!({
+                "role": message.role,
+                "contentLength": message.content.len()
+            }),
+            serde_json::json!({
+                "saved": true,
+                "filename": filename
+            })
+        ).await?;
+
+        // List saved conversations
+        let files = agent.fs.readdir("/conversations").await?;
+        println!("Saved conversations: {:?}", files);
+
+        Ok(())
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Working with Files
+
+AgentFS provides a POSIX-like filesystem API for managing agent-generated content:
+
+```typescript
+// Create directories
+await agent.fs.mkdir('/reports');
+await agent.fs.mkdir('/reports/2024');
+
+// Write files
+const report = "# Q4 2024 Analysis\n\nKey findings...";
+await agent.fs.writeFile(
+  '/reports/2024/q4-analysis.md',
+  report
+);
+
+// Read files
+const content = await agent.fs.readFile(
+  '/reports/2024/q4-analysis.md'
+);
+console.log(content.toString());
+
+// List directory contents
+const reports = await agent.fs.readdir('/reports/2024');
+console.log('Available reports:', reports);
+
+// Check file metadata
+const stats = await agent.fs.stat(
+  '/reports/2024/q4-analysis.md'
+);
+console.log('File size:', stats.size);
+console.log('Created:', new Date(stats.ctime * 1000));
+```
+
+## Managing Agent State
+
+Use the key-value store for fast access to agent configuration and state:
+
+```typescript
+// Store structured data
+await agent.kv.set('user:preferences', {
+  theme: 'dark',
+  language: 'en',
+  notifications: true
+});
+
+// Store conversation context
+await agent.kv.set('context:current', {
+  topic: 'data analysis',
+  tools: ['calculator', 'chart_generator'],
+  startTime: Date.now()
+});
+
+// Retrieve values
+const preferences = await agent.kv.get('user:preferences');
+const context = await agent.kv.get('context:current');
+
+// Delete keys
+await agent.kv.delete('context:previous');
+
+// List all keys with a prefix
+const userKeys = await agent.kv.list({ prefix: 'user:' });
+console.log('User data keys:', userKeys);
+```
+
+## Tracking Tool Calls
+
+Every tool invocation can be automatically tracked for debugging and compliance:
+
+```typescript
+// Record a web search
+const startTime = Date.now() / 1000;
+const results = await performWebSearch(
+  'AgentFS tutorial'
+);
+const endTime = Date.now() / 1000;
+
+await agent.tools.record(
+  'web_search',
+  startTime,
+  endTime,
+  { query: 'AgentFS tutorial', maxResults: 10 },
+  {
+    resultsFound: results.length,
+    topResult: results[0]?.url
+  }
+);
+
+// Record an API call
+await agent.tools.record(
+  'openai_completion',
+  Date.now() / 1000,
+  Date.now() / 1000 + 2.5,
+  { model: 'gpt-4', temperature: 0.7 },
+  { tokensUsed: 1500, success: true }
+);
+
+// Query tool usage
+const recentTools = await agent.tools.list({ limit: 10 });
+console.log('Recent tool calls:', recentTools);
+
+// Get specific tool call
+const toolCall = await agent.tools.get(recentTools[0].id);
+console.log('Tool details:', toolCall);
+```
+
+## Querying Agent History
+
+Since AgentFS is built on Turso, you can query your agent's behavior with SQL:
+
+```typescript
+// Get the underlying database connection
+const db = agent.db;
+
+// Find all files created in the last hour
+const recentFiles = await db.prepare(`
+  SELECT * FROM events
+  WHERE type = 'file_write'
+  AND timestamp > datetime('now', '-1 hour')
+  ORDER BY timestamp DESC
+`).all();
+
+// Analyze tool usage patterns
+const toolStats = await db.prepare(`
+  SELECT
+    name as tool_name,
+    COUNT(*) as usage_count,
+    AVG(julianday(ended_at) -
+        julianday(started_at)) * 86400
+        as avg_duration_seconds
+  FROM toolcalls
+  GROUP BY name
+  ORDER BY usage_count DESC
+`).all();
+
+console.log('Tool usage statistics:', toolStats);
+```
+
+## Best Practices
+
+### 1. Structure Your Filesystem
+
+Organize files logically for easy navigation:
+
+```
+/
+├── conversations/     # Chat histories
+├── outputs/          # Generated content
+├── cache/           # Temporary data
+├── logs/            # Agent logs
+└── config/          # Configuration files
+```
+
+### 2. Use Consistent Key Naming
+
+Adopt a naming convention for KV store keys:
+
+```typescript
+// Good: Hierarchical and clear
+await agent.kv.set(
+  'user:123:preferences', {...}
+);
+await agent.kv.set(
+  'session:abc:context', {...}
+);
+await agent.kv.set(
+  'cache:api:response:xyz', {...}
+);
+
+// Avoid: Flat and ambiguous
+await agent.kv.set('prefs', {...});
+await agent.kv.set('data1', {...});
+```
+
+### 3. Track Important Operations
+
+Record tool calls for critical operations:
+
+```typescript
+async function generateReport(data: any) {
+  const start = Date.now() / 1000;
+
+  try {
+    const report = await createReport(data);
+
+    await agent.tools.record(
+      'generate_report',
+      start,
+      Date.now() / 1000,
+      { dataSize: data.length },
+      { success: true, reportId: report.id }
+    );
+
+    return report;
+  } catch (error) {
+    await agent.tools.record(
+      'generate_report',
+      start,
+      Date.now() / 1000,
+      { dataSize: data.length },
+      { success: false, error: error.message }
+    );
+    throw error;
+  }
+}
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="TypeScript SDK Reference" icon="js" href="/agentfs/sdk/typescript">
+    Complete API documentation for TypeScript/JavaScript
+  </Card>
+  <Card title="Rust SDK Reference" icon="rust" href="/agentfs/sdk/rust">
+    Complete API documentation for Rust
+  </Card>
+  <Card title="Examples" icon="github" href="https://github.com/tursodatabase/agentfs/tree/main/examples">
+    Browse complete example applications
+  </Card>
+  <Card title="Architecture Guide" icon="book" href="/agentfs/architecture">
+    Deep dive into AgentFS internals
+  </Card>
+</CardGroup>

--- a/agentfs/sdk/rust.mdx
+++ b/agentfs/sdk/rust.mdx
@@ -1,0 +1,393 @@
+---
+title: Rust SDK
+description: Complete reference for the AgentFS Rust SDK
+sidebarTitle: Rust SDK
+---
+
+Build high-performance stateful AI agents with the AgentFS Rust SDK.
+
+## Installation
+
+Add AgentFS to your `Cargo.toml`:
+
+```toml
+[dependencies]
+agentfs = "0.1"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+```
+
+## Quick Start
+
+```rust
+use agentfs::AgentFS;
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Open or create an agent filesystem
+    let agent = AgentFS::open("./agent.db").await?;
+
+    // Use the three main APIs
+    agent.kv.set("key", "value").await?;              // Key-value store
+    agent.fs.write_file("/file.txt", b"data").await?; // Filesystem
+    agent.tools.record(...).await?;                   // Tool tracking
+
+    Ok(())
+}
+```
+
+## Core APIs
+
+### AgentFS Struct
+
+The main entry point for all AgentFS operations.
+
+#### `AgentFS::open(path: impl AsRef<Path>)`
+
+Creates or opens an AgentFS database.
+
+```rust
+use agentfs::{AgentFS, AgentFSOptions};
+
+// Simple open
+let agent = AgentFS::open("./my-agent.db").await?;
+
+// With options
+let agent = AgentFS::open_with_options(
+    "./agent.db",
+    AgentFSOptions {
+        readonly: false,
+        create_if_missing: true,
+    }
+).await?;
+```
+
+#### Fields
+
+- `kv`: Key-value store interface
+- `fs`: Filesystem interface
+- `tools`: Tool call tracking interface
+- `db`: Direct access to the underlying Turso database
+
+### Key-Value Store API
+
+Fast, typed storage with Serde serialization support.
+
+#### `kv.set<T: Serialize>(key: &str, value: T)`
+
+Store any serializable value.
+
+```rust
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+struct UserPreferences {
+    theme: String,
+    language: String,
+}
+
+// Store structured data
+agent.kv.set("user:preferences", UserPreferences {
+    theme: "dark".to_string(),
+    language: "en".to_string(),
+}).await?;
+
+// Store primitives
+agent.kv.set("counter", 42).await?;
+agent.kv.set("active", true).await?;
+```
+
+#### `kv.get<T: DeserializeOwned>(key: &str) -> Option<T>`
+
+Retrieve and deserialize values.
+
+```rust
+// Get with type inference
+let prefs: Option<UserPreferences> = agent.kv.get("user:preferences").await?;
+
+// Handle missing values
+if let Some(count) = agent.kv.get::<i32>("counter").await? {
+    println!("Counter: {}", count);
+}
+
+// With default
+let theme = agent.kv.get::<String>("theme").await?.unwrap_or("light".to_string());
+```
+
+#### `kv.delete(key: &str)`
+
+Remove a key-value pair.
+
+```rust
+agent.kv.delete("session:expired").await?;
+```
+
+#### `kv.list(options: ListOptions)`
+
+List keys with filtering and pagination.
+
+```rust
+use agentfs::ListOptions;
+
+// List all keys
+let all_keys = agent.kv.list(ListOptions::default()).await?;
+
+// Filter by prefix
+let user_keys = agent.kv.list(ListOptions {
+    prefix: Some("user:".to_string()),
+    limit: Some(100),
+    cursor: None,
+}).await?;
+
+// Paginate
+let page1 = agent.kv.list(ListOptions {
+    limit: Some(10),
+    ..Default::default()
+}).await?;
+
+let page2 = agent.kv.list(ListOptions {
+    limit: Some(10),
+    cursor: page1.cursor,
+    ..Default::default()
+}).await?;
+```
+
+#### `kv.clear()`
+
+Remove all key-value pairs.
+
+```rust
+agent.kv.clear().await?;
+```
+
+### Filesystem API
+
+POSIX-like filesystem operations for managing agent data.
+
+#### `fs.write_file(path: &str, data: &[u8])`
+
+Write bytes to a file, creating parent directories as needed.
+
+```rust
+// Write text
+agent.fs.write_file("/report.md", b"# Report\nContent...").await?;
+
+// Write string
+let content = "Hello, World!";
+agent.fs.write_file("/greeting.txt", content.as_bytes()).await?;
+
+// Write binary
+let image_data = std::fs::read("./chart.png")?;
+agent.fs.write_file("/images/chart.png", &image_data).await?;
+```
+
+#### `fs.read_file(path: &str) -> Vec<u8>`
+
+Read file contents as bytes.
+
+```rust
+// Read as bytes
+let data = agent.fs.read_file("/report.md").await?;
+
+// Convert to string
+let text = String::from_utf8(data)?;
+
+// Parse JSON
+let json_data = agent.fs.read_file("/config.json").await?;
+let config: serde_json::Value = serde_json::from_slice(&json_data)?;
+```
+
+#### `fs.mkdir(path: &str)`
+
+Create a directory, optionally creating parent directories.
+
+```rust
+// Create single directory
+agent.fs.mkdir("/reports").await?;
+
+// Create nested directories
+agent.fs.mkdir_p("/reports/2024/Q4").await?;
+```
+
+#### `fs.readdir(path: &str) -> Vec<DirEntry>`
+
+List directory contents with metadata.
+
+```rust
+let entries = agent.fs.readdir("/reports").await?;
+
+for entry in entries {
+    println!("Name: {}", entry.name);
+    println!("Type: {:?}", entry.entry_type);
+    println!("Size: {} bytes", entry.size);
+    println!("Modified: {:?}", entry.modified);
+}
+
+// Filter by type
+let files: Vec<_> = entries
+    .iter()
+    .filter(|e| e.entry_type == EntryType::File)
+    .collect();
+```
+
+#### `fs.stat(path: &str) -> FileStat`
+
+Get file or directory metadata.
+
+```rust
+let stat = agent.fs.stat("/report.md").await?;
+
+println!("Size: {} bytes", stat.size);
+println!("Type: {:?}", stat.file_type);
+println!("Created: {:?}", stat.created);
+println!("Modified: {:?}", stat.modified);
+println!("Permissions: {:o}", stat.mode);
+
+if stat.is_file() {
+    println!("It's a file");
+} else if stat.is_directory() {
+    println!("It's a directory");
+}
+```
+
+#### `fs.exists(path: &str) -> bool`
+
+Check if a file or directory exists.
+
+```rust
+if agent.fs.exists("/config.json").await? {
+    let config = agent.fs.read_file("/config.json").await?;
+}
+```
+
+#### `fs.rm(path: &str)`
+
+Remove a file or empty directory.
+
+```rust
+// Remove file
+agent.fs.rm("/old-report.md").await?;
+
+// Remove empty directory
+agent.fs.rm("/empty-dir").await?;
+
+// Remove directory tree
+agent.fs.rm_rf("/old-data").await?;
+```
+
+#### `fs.rename(old_path: &str, new_path: &str)`
+
+Move or rename files and directories.
+
+```rust
+// Rename file
+agent.fs.rename("/draft.md", "/final.md").await?;
+
+// Move to different directory
+agent.fs.rename("/temp/data.json", "/archive/data.json").await?;
+```
+
+#### `fs.copy_file(src: &str, dest: &str)`
+
+Copy a file to a new location.
+
+```rust
+agent.fs.copy_file("/template.md", "/new-report.md").await?;
+```
+
+### Tool Call Tracking API
+
+Record and query agent tool invocations.
+
+#### `tools.record()`
+
+Record a tool invocation with timing and I/O data.
+
+```rust
+use agentfs::ToolCall;
+use chrono::Utc;
+use serde_json::json;
+
+let start = Utc::now();
+// ... perform operation ...
+let end = Utc::now();
+
+agent.tools.record(ToolCall {
+    name: "web_search".to_string(),
+    started_at: start,
+    ended_at: end,
+    input: json!({
+        "query": "rust async programming",
+        "max_results": 10
+    }),
+    output: json!({
+        "results_count": 8,
+        "success": true
+    }),
+}).await?;
+```
+
+#### `tools.list(options: ToolListOptions)`
+
+Query recorded tool calls.
+
+```rust
+use agentfs::ToolListOptions;
+use chrono::{Duration, Utc};
+
+// Get recent calls
+let recent = agent.tools.list(ToolListOptions {
+    limit: Some(10),
+    ..Default::default()
+}).await?;
+
+// Filter by name
+let searches = agent.tools.list(ToolListOptions {
+    name: Some("web_search".to_string()),
+    limit: Some(100),
+    ..Default::default()
+}).await?;
+
+// Time range query
+let last_hour = agent.tools.list(ToolListOptions {
+    since: Some(Utc::now() - Duration::hours(1)),
+    until: Some(Utc::now()),
+    ..Default::default()
+}).await?;
+```
+
+#### `tools.get(id: &str) -> Option<ToolCall>`
+
+Get details of a specific tool call.
+
+```rust
+if let Some(call) = agent.tools.get("call_123abc").await? {
+    let duration = call.ended_at - call.started_at;
+    println!("Tool: {}", call.name);
+    println!("Duration: {}ms", duration.num_milliseconds());
+}
+```
+
+#### `tools.delete(id: &str)`
+
+Remove a tool call record.
+
+```rust
+agent.tools.delete("call_123abc").await?;
+```
+
+#### `tools.clear()`
+
+Remove all tool call records.
+
+```rust
+agent.tools.clear().await?;
+```
+
+## Support
+
+- [GitHub Issues](https://github.com/tursodatabase/agentfs/issues) - Bug reports and feature requests
+- [Discord](https://tur.so/discord) - Community support
+- [Examples](https://github.com/tursodatabase/agentfs/tree/main/examples/rust) - Sample applications

--- a/agentfs/sdk/typescript.mdx
+++ b/agentfs/sdk/typescript.mdx
@@ -1,0 +1,371 @@
+---
+title: TypeScript/JavaScript SDK
+description: Complete reference for the AgentFS TypeScript and JavaScript SDK
+sidebarTitle: TypeScript SDK
+---
+
+Build stateful AI agents with the AgentFS TypeScript SDK, supporting both Node.js and browser environments.
+
+## Installation
+
+```bash
+bun add agentfs-sdk
+```
+
+## Quick Start
+
+```typescript
+import { AgentFS } from 'agentfs-sdk';
+
+// Open or create an agent filesystem
+const agent = await AgentFS.open('./agent.db');
+
+// Use the three main APIs
+// Key-value store
+await agent.kv.set('key', 'value');
+// Filesystem
+await agent.fs.writeFile('/file.txt', 'data');
+// Tool tracking
+await agent.tools.record(...);
+```
+
+## Core APIs
+
+### AgentFS Class
+
+The main entry point for all AgentFS operations.
+
+#### `AgentFS.open(path: string, options?: AgentFSOptions)`
+
+Creates or opens an AgentFS database.
+
+```typescript
+interface AgentFSOptions {
+  // Optional configuration
+  readonly?: boolean;  // Open in read-only mode
+}
+
+const agent = await AgentFS.open('./my-agent.db');
+const readOnlyAgent = await AgentFS.open(
+  './agent.db',
+  { readonly: true }
+);
+```
+
+#### Properties
+
+- `kv`: Key-value store interface
+- `fs`: Filesystem interface
+- `tools`: Tool call tracking interface
+- `db`: Direct access to the underlying Turso database
+
+### Key-Value Store API
+
+Fast, typed storage for agent state and configuration.
+
+#### `kv.set(key: string, value: any)`
+
+Store a value with automatic JSON serialization.
+
+```typescript
+await agent.kv.set('user:123', {
+  name: 'Alice',
+  preferences: { theme: 'dark' }
+});
+
+await agent.kv.set('session:current', 'abc-123');
+await agent.kv.set('counter', 42);
+```
+
+#### `kv.get<T>(key: string): Promise<T | null>`
+
+Retrieve a value with automatic deserialization.
+
+```typescript
+interface UserData {
+  name: string;
+  preferences: { theme: string };
+}
+
+const user = await agent.kv.get<UserData>('user:123');
+if (user) {
+  console.log(user.name); // Type-safe access
+}
+```
+
+#### `kv.delete(key: string)`
+
+Remove a key-value pair.
+
+```typescript
+await agent.kv.delete('session:expired');
+```
+
+#### `kv.list(options?: ListOptions)`
+
+List keys with optional filtering.
+
+```typescript
+interface ListOptions {
+  prefix?: string;  // Filter by key prefix
+  limit?: number;   // Maximum results
+  cursor?: string;  // Pagination cursor
+}
+
+// List all user keys
+const userKeys = await agent.kv.list(
+  { prefix: 'user:' }
+);
+
+// Paginated listing
+const page1 = await agent.kv.list({ limit: 10 });
+const page2 = await agent.kv.list({
+  limit: 10,
+  cursor: page1.cursor
+});
+```
+
+#### `kv.clear()`
+
+Remove all key-value pairs.
+
+```typescript
+await agent.kv.clear();
+```
+
+### Filesystem API
+
+POSIX-like filesystem operations for managing agent data.
+
+#### `fs.writeFile(path: string, data: string | Buffer)`
+
+Write data to a file, creating parent directories as needed.
+
+```typescript
+// Write text
+await agent.fs.writeFile('/reports/summary.md', '# Report\nContent...');
+
+// Write binary data
+const imageBuffer = await fetch(url).then(r => r.arrayBuffer());
+await agent.fs.writeFile('/images/chart.png', Buffer.from(imageBuffer));
+```
+
+#### `fs.readFile(path: string): Promise<Buffer>`
+
+Read file contents as a Buffer.
+
+```typescript
+const data = await agent.fs.readFile('/reports/summary.md');
+const text = data.toString('utf-8');
+
+// For JSON files
+const jsonData = await agent.fs.readFile('/config.json');
+const config = JSON.parse(jsonData.toString());
+```
+
+#### `fs.mkdir(path: string, options?: MkdirOptions)`
+
+Create a directory.
+
+```typescript
+interface MkdirOptions {
+  recursive?: boolean;  // Create parent directories if needed
+}
+
+await agent.fs.mkdir('/reports/2024/Q4', { recursive: true });
+```
+
+#### `fs.readdir(path: string): Promise<string[]>`
+
+List directory contents.
+
+```typescript
+const files = await agent.fs.readdir('/reports');
+// Returns: ['summary.md', '2024/', 'archive/']
+
+// Check each entry type
+for (const entry of files) {
+  const stats = await agent.fs.stat(`/reports/${entry}`);
+  if (stats.isDirectory()) {
+    console.log(`Directory: ${entry}`);
+  } else {
+    console.log(`File: ${entry} (${stats.size} bytes)`);
+  }
+}
+```
+
+#### `fs.stat(path: string): Promise<Stats>`
+
+Get file or directory metadata.
+
+```typescript
+interface Stats {
+  size: number;        // File size in bytes
+  mode: number;        // File mode/permissions
+  mtime: number;       // Modified time (Unix timestamp)
+  ctime: number;       // Created time (Unix timestamp)
+  isFile(): boolean;
+  isDirectory(): boolean;
+}
+
+const stats = await agent.fs.stat('/reports/summary.md');
+console.log(`Size: ${stats.size} bytes`);
+console.log(`Modified: ${new Date(stats.mtime * 1000)}`);
+```
+
+#### `fs.exists(path: string): Promise<boolean>`
+
+Check if a file or directory exists.
+
+```typescript
+if (await agent.fs.exists('/reports/draft.md')) {
+  console.log('Draft exists');
+}
+```
+
+#### `fs.rm(path: string, options?: RmOptions)`
+
+Remove a file or directory.
+
+```typescript
+interface RmOptions {
+  recursive?: boolean;  // Remove directories and contents
+  force?: boolean;     // Don't error if doesn't exist
+}
+
+// Remove a file
+await agent.fs.rm('/reports/old.md');
+
+// Remove directory tree
+await agent.fs.rm('/archive', { recursive: true });
+
+// Safe removal
+await agent.fs.rm('/maybe-exists.txt', { force: true });
+```
+
+#### `fs.rename(oldPath: string, newPath: string)`
+
+Move or rename a file or directory.
+
+```typescript
+await agent.fs.rename('/reports/draft.md', '/reports/final.md');
+await agent.fs.rename('/temp', '/archive/2024');
+```
+
+#### `fs.copyFile(src: string, dest: string)`
+
+Copy a file to a new location.
+
+```typescript
+await agent.fs.copyFile('/reports/template.md', '/reports/new-report.md');
+```
+
+### Tool Call Tracking API
+
+Record and query agent tool invocations for debugging and compliance.
+
+#### `tools.record(name, startTime, endTime, input, output)`
+
+Record a tool invocation.
+
+```typescript
+await agent.tools.record(
+  name: string,           // Tool identifier
+  startTime: number,      // Unix timestamp (seconds)
+  endTime: number,        // Unix timestamp (seconds)
+  input: any,            // Tool input (JSON-serializable)
+  output: any            // Tool output (JSON-serializable)
+);
+
+// Example: Track an API call
+const start = Date.now() / 1000;
+const response = await callOpenAI(prompt);
+
+await agent.tools.record(
+  'openai_completion',
+  start,
+  Date.now() / 1000,
+  { prompt, model: 'gpt-4', temperature: 0.7 },
+  { response, tokensUsed: 150 }
+);
+```
+
+#### `tools.list(options?: ToolListOptions)`
+
+Query recorded tool calls.
+
+```typescript
+interface ToolListOptions {
+  limit?: number;      // Maximum results
+  offset?: number;     // Skip results
+  name?: string;       // Filter by tool name
+  since?: number;      // After timestamp
+  until?: number;      // Before timestamp
+}
+
+// Get recent tool calls
+const recent = await agent.tools.list({ limit: 10 });
+
+// Get specific tool usage
+const searches = await agent.tools.list({
+  name: 'web_search',
+  limit: 100
+});
+
+// Get calls from last hour
+const lastHour = await agent.tools.list({
+  since: Date.now() / 1000 - 3600
+});
+```
+
+#### `tools.get(id: string)`
+
+Get details of a specific tool call.
+
+```typescript
+const toolCall = await agent.tools.get('call_123abc');
+console.log('Duration:', toolCall.endTime - toolCall.startTime, 'seconds');
+```
+
+#### `tools.delete(id: string)`
+
+Remove a tool call record.
+
+```typescript
+await agent.tools.delete('call_123abc');
+```
+
+#### `tools.clear()`
+
+Remove all tool call records.
+
+```typescript
+await agent.tools.clear();
+```
+
+## Browser Support
+
+AgentFS works in browser environments using WebAssembly:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="module">
+    import { AgentFS } from 'https://unpkg.com/agentfs-sdk/dist/browser.js';
+
+    const agent = await AgentFS.open('browser-agent.db');
+
+    // All APIs work the same in browser
+    await agent.kv.set('browser:data', { platform: 'web' });
+    await agent.fs.writeFile('/notes.txt', 'Hello from browser!');
+  </script>
+</head>
+</html>
+```
+
+## Support
+
+- [GitHub Issues](https://github.com/tursodatabase/agentfs/issues) - Bug reports and feature requests
+- [Discord](https://tur.so/discord) - Community support and discussions
+- [Examples](https://github.com/tursodatabase/agentfs/tree/main/examples) - Sample applications

--- a/docs.json
+++ b/docs.json
@@ -493,6 +493,25 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "AgentFS",
+        "groups": [
+          {
+            "group": "AgentFS",
+            "pages": [
+              "agentfs/introduction",
+              "agentfs/quickstart"
+            ]
+          },
+          {
+            "group": "SDKs",
+            "pages": [
+              "agentfs/sdk/typescript",
+              "agentfs/sdk/rust"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/guides/agent-databases.mdx
+++ b/guides/agent-databases.mdx
@@ -2,6 +2,10 @@
 title: Agent Databases
 ---
 
+<Info>
+Looking for a complete agent state management solution? Check out [AgentFS](/agentfs/introduction) - our specialized SDK designed specifically for AI agents, offering filesystem operations, key-value storage, and automatic tool call tracking in a single database file.
+</Info>
+
 AI agents need databases to store context, track state, and maintain memory across executions. Turso Database offers two powerful approaches:
 
 - **Embedded Databases** for local-first agent processing, and

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -12,11 +12,13 @@ sidebarTitle: Introduction
 
 Turso is the small database to power your big dreams in the age of AI. The most efficient way to build for traditional applications, smart devices, embodied AI, agents, and anything in between.
 
+**New:** [AgentFS](/agentfs/introduction) - A specialized filesystem and state management SDK for AI agents, providing auditability, reproducibility, and portability in a single database file.
+
 ## Get Started
 
 Choose your path to get started with Turso:
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card
     title="Turso Database (Embedded)"
     icon="microchip"
@@ -24,6 +26,9 @@ Choose your path to get started with Turso:
   >
     An embedded database engine that goes anywhere. Offline, in the browser, or
     on-device.
+  </Card>
+  <Card title="AgentFS" icon="robot" href="/agentfs/introduction">
+    Filesystem and state SDK for AI agents with built-in auditability.
   </Card>
   <Card title="Turso Cloud" icon="cloud" href="/turso-cloud">
     Fully managed database platform with branching, analytics, backups,and more.


### PR DESCRIPTION
- Create comprehensive AgentFS documentation with introduction, quickstart, and SDK guides
- Add TypeScript and Rust SDK reference documentation
- Integrate AgentFS into main navigation as a new tab
- Update homepage to feature AgentFS alongside Turso Database and Turso Cloud
- Add cross-references to AgentFS in existing agent documentation

🤖 Generated with [Claude Code](https://claude.ai/code)