### PR TITLE
Update quickstart.mdx

### DIFF
--- a/agentfs/quickstart.mdx
+++ b/agentfs/quickstart.mdx
@@ -88,7 +88,7 @@ Let's build a simple agent that maintains conversation history and generates fil
     );
     await addMessage(
       'assistant',
-      'Of course! I'd be happy to help.'
+      "Of course! I'd be happy to help."
     );
 
     // Retrieve conversation history


### PR DESCRIPTION
Fix broken tutorial code - message in second addMessage() should be wrapped double quotes

```
// Example usage
await addMessage(
  'user',
  'Hello, can you help me with a task?'
);
await addMessage(
  'assistant',
  'Of course! I'd be happy to help.'
);
```
From https://docs.turso.tech/agentfs/quickstart#create-your-first-agent
