### PR TITLE
fix stale discord links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ## Support
 
-Join us [on Discord](https://tur.so/discord-c) to get help using this SDK. Report security issues [via email](mailto:security@turso.tech).
+Join us [on Discord](https://tur.so/discord) to get help using this SDK. Report security issues [via email](mailto:security@turso.tech).
 
 ## Contributors
 

--- a/_snippets/technical-preview-banner.mdx
+++ b/_snippets/technical-preview-banner.mdx
@@ -1,5 +1,5 @@
 <Warning>
 
-This is currently in technical preview. [Join us in Discord](https://discord.gg/turso) to report any issues.
+This is currently in technical preview. [Join us in Discord](https://tur.so/discord) to report any issues.
 
 </Warning>

--- a/docs.json
+++ b/docs.json
@@ -27,7 +27,7 @@
         {
           "anchor": "Discord",
           "icon": "discord",
-          "href": "https://discord.gg/turso"
+          "href": "https://tur.so/discord"
         },
         {
           "anchor": "GitHub",
@@ -594,7 +594,7 @@
   },
   "footer": {
     "socials": {
-      "discord": "https://discord.gg/turso",
+      "discord": "https://tur.so/discord",
       "github": "https://github.com/tursodatabase",
       "twitter": "https://twitter.com/tursodatabase",
       "linkedin": "https://www.linkedin.com/company/turso"

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -73,7 +73,7 @@ Connect with developers and the Turso team:
   >
     Join the core development community for Turso Database discussions
   </Card>
-  <Card title="Turso Community" icon="discord" href="https://discord.gg/turso">
+  <Card title="Turso Community" icon="discord" href="https://tur.so/discord">
     Connect with users and get support for Turso Cloud
   </Card>
 </CardGroup>

--- a/libsql.mdx
+++ b/libsql.mdx
@@ -17,7 +17,7 @@ Browse the libSQL source code on GitHub, report issues, feature requests and con
 
 </Card>
 
-<Card title="Discord" href="https://discord.gg/turso" icon="discord">
+<Card title="Discord" href="https://tur.so/discord" icon="discord">
 
 Join the community on Discord to talk about the development of libSQL.
 

--- a/sdk/flutter/quickstart.mdx
+++ b/sdk/flutter/quickstart.mdx
@@ -6,7 +6,7 @@ description: Get started with Flutter and Dart using the libSQL client in a few 
 
 <Note>
 
-This SDK is community maintained and may not be officially supported by Turso, or up to date with the latest features. Join the `#libsql-dart` channel [on Discord](https://discord.gg/turso) for help and feedback.
+This SDK is community maintained and may not be officially supported by Turso, or up to date with the latest features. Join the `#libsql-dart` channel [on Discord](https://tur.so/discord) for help and feedback.
 
 </Note>
 

--- a/sdk/rust/reference.mdx
+++ b/sdk/rust/reference.mdx
@@ -106,7 +106,7 @@ db.sync().await.unwrap(); // Call sync manually to update local database
 
 <Info>
 
-If you require full control over how frames get from your instance of `sqld` (libSQL Server), you can do this using `new_local_replica` and `sync_frames`. Reach out to us [on Discord](https://discord.gg/turso) if you want to learn more.
+If you require full control over how frames get from your instance of `sqld` (libSQL Server), you can do this using `new_local_replica` and `sync_frames`. Reach out to us [on Discord](https://tur.so/discord) if you want to learn more.
 
 </Info>
 

--- a/support.mdx
+++ b/support.mdx
@@ -11,7 +11,7 @@ If you're new to Turso, the easiest way to get started is with this quickstart.
 
 </Card>
 
-<Card title="Discord" href="https://discord.gg/turso" icon="discord">
+<Card title="Discord" href="https://tur.so/discord" icon="discord">
 
 Show off what you're working on, ask for help, and chat with the community.
 

--- a/turso-cloud.mdx
+++ b/turso-cloud.mdx
@@ -247,10 +247,10 @@ Learn how to manage, distribute and integrate your databases with the CLI, API a
 
 ## Community
 
-Join the Turso community to ask questions, share what you're working on, discuss best practices, and share tips on [Discord](https://discord.gg/turso), [Twitter](https://twitter.com/tursodatabase), and [LinkedIn](https://www.linkedin.com/company/turso).
+Join the Turso community to ask questions, share what you're working on, discuss best practices, and share tips on [Discord](https://tur.so/discord), [Twitter](https://twitter.com/tursodatabase), and [LinkedIn](https://www.linkedin.com/company/turso).
 
 <CardGroup cols={3}>
-  <Card title="Discord" icon="discord" href="https://discord.gg/turso" />
+  <Card title="Discord" icon="discord" href="https://tur.so/discord" />
   <Card
     title="GitHub"
     icon="star"


### PR DESCRIPTION
stale discord links (discord.gg/turso) are used throughout the application. tur.so/discord seems to be the new link.