### PR TITLE
Rename experimental_mvcc journal mode to mvcc

### DIFF
--- a/sql-reference/pragmas.mdx
+++ b/sql-reference/pragmas.mdx
@@ -219,10 +219,10 @@ PRAGMA journal_mode = wal;
 Turso supports WAL (Write-Ahead Logging) mode. Rollback journal modes (DELETE, TRUNCATE, PERSIST, MEMORY) are not supported.
 
 <Info>
-**Turso Extension**: Turso supports an experimental MVCC journal mode for concurrent writes:
+**Turso Extension**: Turso supports an MVCC journal mode for concurrent writes:
 
 ```sql
-PRAGMA journal_mode = experimental_mvcc;
+PRAGMA journal_mode = mvcc;
 ```
 
 When MVCC mode is active, you can use `BEGIN CONCURRENT` for optimistic concurrent write transactions. See [Transactions](/sql-reference/statements/transactions#begin-concurrent) for details.

--- a/sql-reference/statements/transactions.mdx
+++ b/sql-reference/statements/transactions.mdx
@@ -127,7 +127,7 @@ BEGIN CONCURRENT [TRANSACTION];
 BEGIN CONCURRENT requires MVCC mode. Enable it by setting the journal mode before opening any transactions:
 
 ```sql
-PRAGMA journal_mode = experimental_mvcc;
+PRAGMA journal_mode = mvcc;
 ```
 
 ### How It Works
@@ -145,13 +145,13 @@ This provides **snapshot isolation**: each transaction sees a consistent view of
 
 ```sql
 -- Connection 1
-PRAGMA journal_mode = experimental_mvcc;
+PRAGMA journal_mode = mvcc;
 BEGIN CONCURRENT;
 UPDATE accounts SET balance = balance - 100 WHERE id = 1;
 COMMIT;
 
 -- Connection 2 (running simultaneously)
-PRAGMA journal_mode = experimental_mvcc;
+PRAGMA journal_mode = mvcc;
 BEGIN CONCURRENT;
 UPDATE accounts SET balance = balance + 50 WHERE id = 2;
 COMMIT;


### PR DESCRIPTION
After the fix in https://github.com/tursodatabase/turso/issues/5658, it would be better for users if the documentation referenced mvcc instead of experimental_mvcc.