### PR TITLE
Replace libSQL sync with Turso Sync in SDK docs

### DIFF
--- a/features/embedded-replicas/introduction.mdx
+++ b/features/embedded-replicas/introduction.mdx
@@ -3,9 +3,9 @@ title: Embedded Replicas
 sidebarTitle: Introduction
 ---
 
-<Note>
-  Embedded Replicas are a Turso Cloud feature built on [libSQL](/libsql). For new projects, consider using [Turso Sync](/sync/usage), which is built on the Turso Database rewrite and offers a simpler push/pull model.
-</Note>
+<Warning>
+  Embedded Replicas are a legacy Turso Cloud feature built on [libSQL](/libsql). **Writes are sent to the remote primary database, not stored locally.** For new projects that need sync, use [Turso Sync](/sync/usage), which is built on the Turso Database engine and provides true local-first reads and writes with explicit push/pull.
+</Warning>
 
 Turso Cloud's embedded replicas let you replicate a database right within your application. This is especially useful for VMs or VPS deployments, and for mobile applications where stable connectivity is a challenge, since they allow uninterrupted access to the local database.
 
@@ -27,7 +27,7 @@ Embedded replicas provide a smooth switch between local and remote database oper
 
 4. You write to a database:
 
-   - Writes are sent to the remote primary database configured at `syncUrl` by default.
+   - **Writes are sent to the remote primary database** configured at `syncUrl` by default. They are NOT written to the local file first.
    - You can write locally if you set the `offline` config option to `true`.
    - Any write transactions with reads are also sent to the remote primary database.
    - Once the write is successful, the local database is updated with the changes automatically (read your own writes, can be disabled).

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -40,6 +40,10 @@ Choose your path to get started with Turso:
   </Card>
 </CardGroup>
 
+<Info>
+  **Need sync?** If you want local reads and writes with push/pull sync to the cloud, start with [Turso Database](/tursodb/quickstart) and [Turso Sync](/sync/usage).
+</Info>
+
 ## Turso Database Features
 
 The next evolution of SQLite, built for modern applications:

--- a/sdk/go/quickstart.mdx
+++ b/sdk/go/quickstart.mdx
@@ -6,11 +6,6 @@ description: Get started with Turso and Go using the libSQL client in a few simp
 
 The libSQL package is designed to work with [`database/sql`](https://pkg.go.dev/database/sql) to provide the usual methods you'd expect when working with databases in Go.
 
-<Info>
-
-The `go-libsql` package uses CGO. You can use `github.com/tursodatabase/libsql-client-go/libsql` instead, but it doesn't support embedded replicas.
-
-</Info>
 
 In this Go quickstart we will learn how to:
 
@@ -18,7 +13,7 @@ In this Go quickstart we will learn how to:
 - Install Go libSQL
 - Connect to a local or remote Turso database
 - Execute a query using SQL
-- Sync changes to local database (optional)
+- Sync changes to local database
 
 <Steps>
   <Step title="Retrieve database credentials">
@@ -36,7 +31,7 @@ You will need an existing database to continue. If you don't have one, [create o
 First begin by adding libSQL to your project:
 
 <AccordionGroup>
-  <Accordion title="Local / Embedded Replicas">
+  <Accordion title="Local">
     ```bash
     go get github.com/tursodatabase/go-libsql
     ```
@@ -59,50 +54,10 @@ First begin by adding libSQL to your project:
 Now connect to your local or remote database using the libSQL connector:
 
 <AccordionGroup>
-  <Accordion title="Embedded Replicas">
-    ```go
-    package main
-
-    import (
-      "database/sql"
-      "fmt"
-      "os"
-      "path/filepath"
-
-      "github.com/tursodatabase/go-libsql"
-    )
-
-    func main() {
-        dbName := "local.db"
-        primaryUrl := "libsql://[DATABASE].turso.io"
-        authToken := "..."
-
-        dir, err := os.MkdirTemp("", "libsql-*")
-        if err != nil {
-            fmt.Println("Error creating temporary directory:", err)
-            os.Exit(1)
-        }
-        defer os.RemoveAll(dir)
-
-        dbPath := filepath.Join(dir, dbName)
-
-        connector, err := libsql.NewEmbeddedReplicaConnector(dbPath, primaryUrl,
-            libsql.WithAuthToken(authToken),
-        )
-        if err != nil {
-            fmt.Println("Error creating connector:", err)
-            os.Exit(1)
-        }
-        defer connector.Close()
-
-        db := sql.OpenDB(connector)
-        defer db.Close()
-    }
-    ```
-
-  </Accordion>
-
   <Accordion title="Local only">
+
+    <Info>Starting a new project? Consider using [Turso Database](/tursodb/quickstart) for Go — it offers concurrent writes, vector search, and a modern async engine built on the next evolution of SQLite.</Info>
+
     ```go
     package main
 
@@ -203,26 +158,9 @@ queryUsers(db)
 
   </Step>
 
-  <Step title="Sync (Embedded Replicas only)">
+  <Step title="Sync">
 
-When using embedded replicas you should call `Sync()` on the connector to sync your local database with the primary database.
-
-```go
-if err := connector.Sync(); err != nil {
-  fmt.Println("Error syncing database:", err)
-}
-```
-
-The connector can automatically sync your database at a regular interval when using the `WithSyncInterval` option:
-
-```go
-syncInterval := time.Minute
-
-connector, err := libsql.NewEmbeddedReplicaConnector(dbPath, primaryUrl,
-    libsql.WithAuthToken(authToken),
-    libsql.WithSyncInterval(syncInterval),
-)
-```
+If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides true local-first sync with explicit `push()` and `pull()` operations.
 
   </Step>
 </Steps>

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -5,6 +5,10 @@ title: Turso Cloud SDKs
 
 Turso provides multiple SDKs that you can use to connect a local SQLite file or remote Turso Cloud database, as well as support for embedded databases. If you're using a language or framework that isn't supported with an official driver, you can use Turso over HTTP.
 
+<Info>
+  **Need sync?** If you want local reads and writes with push/pull sync to the cloud, use [Turso Sync](/sync/usage). The SDKs below connect to Turso Cloud using libSQL, where embedded replica sync only replicates reads locally — writes go to the cloud.
+</Info>
+
 ## Official SDKs
 
 Turso SDKs are fully compatible with [libSQL](/libsql), so you can use the same SDK to connect to a local database ([SQLite](/local-development#sqlite)), [libSQL server](/local-development#libsql-server), a remote database, or an [embedded replica](/features/embedded-replicas).

--- a/sdk/python/quickstart.mdx
+++ b/sdk/python/quickstart.mdx
@@ -10,7 +10,7 @@ In this Python quickstart we will learn how to:
 - Install the libSQL package
 - Connect to a Turso database
 - Execute a query using SQL
-- Sync changes to local database (optional)
+- Sync changes to local database
 
 <Steps>
   <Step title="Retrieve database credentials">
@@ -89,19 +89,9 @@ print(conn.execute("select * from users").fetchall())
 
   </Step>
 
-  <Step title="Sync (Embedded Replicas only)">
+  <Step title="Sync">
 
-When using embedded replicas you should call `sync()` on the connector to sync your local database with the primary database.
-
-```py
-conn.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER);")
-conn.execute("INSERT INTO users(id) VALUES (1);")
-conn.commit()
-
-conn.sync()
-
-print(conn.execute("select * from users").fetchall())
-```
+If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides true local-first sync with explicit `push()` and `pull()` operations.
 
   </Step>
 </Steps>

--- a/sdk/rust/quickstart.mdx
+++ b/sdk/rust/quickstart.mdx
@@ -10,7 +10,7 @@ In this Rust quickstart we will learn how to:
 - Install the Rust libSQL crate
 - Connect to a local or remote Turso database
 - Execute a query using SQL
-- Sync changes to local database (optional)
+- Sync changes to local database
 
 <Steps>
   <Step title="Retrieve database credentials">
@@ -118,26 +118,9 @@ while let Some(row) = rows.next().await? {
 
   </Step>
 
-  <Step title="Sync (Embedded Replicas only)">
+  <Step title="Sync">
 
-When using embedded replicas you should call `sync()` on the database type to sync your local database with the primary database:
-
-```rust
-db.sync().await.unwrap();
-```
-
-You can also set up automatic periodic syncing when creating the database:
-
-```rust
-use std::time::Duration;
-
-let db = Builder::new_remote_replica("local.db", url, token)
-    .sync_interval(Duration::from_secs(60))
-    .build()
-    .await?;
-```
-
-This will automatically sync the database every 60 seconds.
+If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides true local-first sync with explicit `push()` and `pull()` operations.
 
   </Step>
 </Steps>

--- a/sdk/ts/quickstart.mdx
+++ b/sdk/ts/quickstart.mdx
@@ -123,4 +123,9 @@ You will need an existing database to continue. If you don't have one, [create o
 </Tabs>
 
   </Step>
+  <Step title="Sync">
+
+If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides true local-first sync with explicit `push()` and `pull()` operations.
+
+  </Step>
 </Steps>


### PR DESCRIPTION
## Summary

- **SDK quickstarts (Go, Python, Rust, TS):** Removed libSQL Embedded Replicas sync steps/code and replaced with a redirect to [Turso Sync](/sync/usage) for true local-first push/pull
- **Go quickstart:** Removed the Embedded Replicas connection accordion entirely (writes go to remote, misleading for local use cases); added callout in Local accordion nudging new projects toward Turso Database
- **Embedded Replicas intro:** Upgraded `<Note>` to `<Warning>` with "legacy" language; bolded that writes go to the remote primary
- **SDK and site introduction pages:** Added `<Info>` callouts directing sync-seeking users to Turso Sync

## Motivation

A Go user followed the SDK quickstart, set up Embedded Replicas expecting local writes + cloud sync, and discovered writes actually go to the cloud. libSQL sync is fundamentally broken for local-first use cases. Turso Sync (`/sync/usage`) is the correct solution but was never referenced from SDK pages.

## Test plan

- [ ] Verify each modified SDK quickstart no longer shows libSQL sync code
- [ ] Verify each modified SDK quickstart links to `/sync/usage`
- [ ] Verify the Embedded Replicas intro page clearly warns against use for new sync projects
- [ ] Verify all links to `/sync/usage` and `/tursodb/quickstart` resolve correctly
- [ ] Confirm no changes to non-Turso SDKs (PHP, Ruby, Swift, Kotlin, C, Flutter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)