### PR TITLE
Add new Turso package documentation and Python quickstart rewrite

### DIFF
--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -1,17 +1,36 @@
 ---
 sidebarTitle: Introduction
-title: Turso Cloud SDKs
+title: Turso SDKs
 ---
 
-Turso provides multiple SDKs that you can use to connect a local SQLite file or remote Turso Cloud database, as well as support for embedded databases. If you're using a language or framework that isn't supported with an official driver, you can use Turso over HTTP.
+## Which package should I use?
+
+| Use case | TypeScript | Python |
+| --- | --- | --- |
+| **Local database** (embedded, on-device, offline) | `@tursodatabase/database` | `pyturso` |
+| **Local database + cloud sync** (push/pull) | `@tursodatabase/sync` | `pyturso` (with sync) |
+| **Remote access** (servers, Docker, serverless, edge — any over-the-wire) | `@tursodatabase/serverless` | `libsql` |
+| **Legacy (libSQL)** — ORM support (Drizzle, Prisma), battle-tested | `@libsql/client` | `libsql` |
+
+**Starting a new project?** Use `@tursodatabase/database` (TypeScript) or `pyturso` (Python). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and true local-first sync.
+
+**Need sync?** Use [Turso Sync](/sync/usage) for local reads and writes with explicit `push()` / `pull()` to Turso Cloud.
+
+**Using an ORM (Drizzle, Prisma)?** Use `@libsql/client` — it has production-ready support from all major ORMs in the ecosystem.
+
+**Migrating from SQLite?** Turso Database is a drop-in replacement. Your existing SQL, schema, and queries work unchanged.
+
+**Already using `@libsql/client` or `libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. They are fully supported and battle-tested. Consider migrating to the Turso Database packages for better sync support and concurrent writes — but if you run into something that doesn't work yet with the newer packages, `@libsql/client` and `libsql` are reliable fallbacks.
+
+### Why multiple packages in TypeScript?
+
+Keeping `@tursodatabase/database` and `@tursodatabase/serverless` separate means minimal bundle size. `@tursodatabase/serverless` uses only `fetch` — zero native dependencies, so it works in Node.js, Docker containers, serverless functions, edge runtimes, and browsers.
 
 <Info>
   **Need sync?** If you want local reads and writes with push/pull sync to the cloud, use [Turso Sync](/sync/usage). The SDKs below connect to Turso Cloud using libSQL, where embedded replica sync only replicates reads locally — writes go to the cloud.
 </Info>
 
 ## Official SDKs
-
-Turso SDKs are fully compatible with [libSQL](/libsql), so you can use the same SDK to connect to a local database ([SQLite](/local-development#sqlite)), [libSQL server](/local-development#libsql-server), a remote database, or an [embedded replica](/features/embedded-replicas).
 
 <Snippet file="official-sdks.mdx" />
 

--- a/sdk/python/quickstart.mdx
+++ b/sdk/python/quickstart.mdx
@@ -1,16 +1,99 @@
 ---
 title: Turso Quickstart (Python)
 sidebarTitle: Quickstart
-description: Get started with Turso and Python using the libSQL client in a few simple steps.
+description: Get started with Turso and Python in a few simple steps.
 ---
 
 In this Python quickstart we will learn how to:
 
-- Retrieve database credentials
-- Install the libSQL package
-- Connect to a Turso database
+- Install the Turso package
+- Connect to a local or remote database
 - Execute a query using SQL
 - Sync changes to local database
+
+## Recommended: pyturso (Local / Embedded)
+
+`pyturso` is the recommended package for local and embedded use cases. It is built on the Turso Database engine — a ground-up rewrite of SQLite with concurrent writes (MVCC) and async I/O. The API follows the standard Python `sqlite3` interface, so it works as a drop-in replacement.
+
+<Steps>
+  <Step title="Install">
+
+```bash
+uv add pyturso
+```
+
+Or with pip:
+
+```bash
+pip install pyturso
+```
+
+  </Step>
+  <Step title="Connect">
+
+```py
+import turso
+
+db = turso.connect("app.db")
+```
+
+In-memory databases are also supported:
+
+```py
+db = turso.connect(":memory:")
+```
+
+  </Step>
+  <Step title="Execute">
+
+```py
+db.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+db.execute("INSERT INTO users (name) VALUES (?)", ("Alice",))
+db.commit()
+
+for row in db.execute("SELECT * FROM users"):
+    print(row)
+```
+
+  </Step>
+  <Step title="Sync (push and pull)">
+
+If you need to sync your local database with Turso Cloud, use `turso.sync`:
+
+```py
+import os
+import turso.sync
+
+db = turso.sync.connect(
+    "app.db",
+    remote_url=os.environ["TURSO_DATABASE_URL"],
+    auth_token=os.environ["TURSO_AUTH_TOKEN"],
+)
+
+db.execute("INSERT INTO users (name) VALUES (?)", ("Bob",))
+db.commit()
+
+# Push local writes to Turso Cloud
+db.push()
+
+# Pull remote changes to local database
+db.pull()
+```
+
+All reads and writes happen against the local database file — fast, offline-capable. `push()` sends your changes to the cloud. `pull()` brings remote changes down. See [Turso Sync](/sync/usage) for details on conflict resolution, checkpointing, and more.
+
+  </Step>
+</Steps>
+
+## Remote Access (Over-the-Wire)
+
+If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), you can use the `libsql` package. It connects to your database via HTTP — no local file needed.
+
+<Info>
+
+For most applications, we recommend running a local database with [Turso Sync](/sync/usage) (`turso.sync`) instead — it gives you faster reads, offline support, and lower latency. Remote access is useful when you cannot store a local database file (e.g., stateless serverless environments).
+
+</Info>
 
 <Steps>
   <Step title="Retrieve database credentials">
@@ -22,76 +105,43 @@ You will need an existing database to continue. If you don't have one, [create o
 <Info>You will want to store these as environment variables.</Info>
 
   </Step>
-
   <Step title="Install">
 
-First begin by adding libSQL to your project:
+```bash
+uv add libsql
+```
 
-    ```bash
-    pip install libsql
-    ```
+Or with pip:
 
-  </Step>
-
-  <Step title="Connect">
-
-Then import the package:
-
-    ```py
-    import libsql
-    ```
-
-Now connect to your local or remote database using the libSQL connector:
-
-<AccordionGroup>
-  <Accordion title="Embedded Replicas">
-    ```py
-    url = os.getenv("TURSO_DATABASE_URL")
-    auth_token = os.getenv("TURSO_AUTH_TOKEN")
-
-    conn = libsql.connect("hello.db", sync_url=url, auth_token=auth_token)
-    conn.sync()
-    ```
-
-  </Accordion>
-
-  <Accordion title="Local only">
-    ```py
-    conn = libsql.connect("hello.db")
-    cur = conn.cursor()
-    ```
-
-  </Accordion>
-
-  {/* <Accordion title="Remote only">
-    ```py
-    url = os.getenv("TURSO_DATABASE_URL")
-    auth_token = os.getenv("TURSO_AUTH_TOKEN")
-
-    conn = libsql.connect(database=url, auth_token=auth_token)
-    ```
-
-  </Accordion> */}
-</AccordionGroup>
-
-  </Step>
-
-  <Step title="Execute">
-
-You can execute SQL queries against your existing database as follows:
-
-```py
-conn.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER);")
-conn.execute("INSERT INTO users(id) VALUES (10);")
-
-print(conn.execute("select * from users").fetchall())
+```bash
+pip install libsql
 ```
 
   </Step>
+  <Step title="Connect and query">
 
-  <Step title="Sync">
+```py
+import os
+import libsql
 
-If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides true local-first sync with explicit `push()` and `pull()` operations.
+conn = libsql.connect(
+    database=os.environ["TURSO_DATABASE_URL"],
+    auth_token=os.environ["TURSO_AUTH_TOKEN"],
+)
+
+conn.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+conn.execute("INSERT INTO users (name) VALUES (?)", ("Alice",))
+conn.commit()
+
+rows = conn.execute("SELECT * FROM users").fetchall()
+print(rows)
+```
 
   </Step>
 </Steps>
+
+## Legacy: libsql (Embedded Replicas)
+
+The `libsql` package also supports embedded replicas, where reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use `turso.sync` instead.
+
+See the [reference](/sdk/python/reference) for full documentation on embedded replicas, encryption, and periodic sync.

--- a/sdk/python/reference.mdx
+++ b/sdk/python/reference.mdx
@@ -1,8 +1,95 @@
 ---
 title: Reference
+description: Python Reference for Turso
 ---
 
+Turso offers two Python packages:
+
+| | `pyturso` | `libsql` (legacy) |
+| --- | --- | --- |
+| **Use case** | Local / embedded database, sync | Legacy — embedded replicas |
+| **Engine** | Turso Database (rewrite) | libSQL (SQLite fork) |
+| **Concurrent writes** | Yes (MVCC) | Not supported |
+| **Sync** | push/pull (true local-first) | Embedded replicas (writes go to remote) |
+| **API** | Python `sqlite3`-compatible | Python `sqlite3`-compatible |
+
+**Starting a new project?** Use `pyturso` — it is built on the Turso Database engine with better performance, concurrent writes, and true local-first sync.
+
+## pyturso
+
+For local and embedded use. Built on the Turso Database engine with concurrent writes (MVCC) and async I/O.
+
+### Installing
+
+```bash
+pip install pyturso
+```
+
+### Connecting
+
+```py
+import turso
+
+conn = turso.connect("app.db")
+```
+
+In-memory databases are also supported:
+
+```py
+conn = turso.connect(":memory:")
+```
+
+### Querying
+
+```py
+conn.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+conn.execute("INSERT INTO users (name) VALUES (?)", ("Alice",))
+conn.commit()
+
+for row in conn.execute("SELECT * FROM users"):
+    print(row)
+```
+
+### Encryption
+
+Encrypt local databases at rest using the `encryption` option:
+
+```py
+from turso import connect, EncryptionOpts
+
+conn = connect("encrypted.db",
+               experimental_features="encryption",
+               encryption=EncryptionOpts(cipher="aegis256",
+                                         hexkey="b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327"))
+```
+
+Supported ciphers: `aegis256`, `aegis256x2`, `aegis128l`, `aegis128x2`, `aegis128x4`, `aes256gcm`, `aes128gcm`.
+
+Encrypted databases cannot be read as standard SQLite databases — you must use the Turso Database engine to open them.
+
+<Info>
+
+Turso Cloud databases can also be encrypted with bring-your-own-key — [learn more](/cloud/encryption).
+
+</Info>
+
+## libsql (Legacy)
+
+The `libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. It is fully supported — if you run into something that doesn't work yet with `pyturso`, `libsql` is a reliable fallback.
+
+<Info>
+
+With `libsql` embedded replicas, reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use `turso.sync` — see the [quickstart](/sdk/python/quickstart).
+
+</Info>
+
 ## Embedded Replicas
+
+<Warning>
+
+For new projects, we recommend `turso.sync` for sync use cases — it is built on the Turso Database engine with better performance, true local-first writes, and concurrent write support. See the [quickstart](/sdk/python/quickstart).
+
+</Warning>
 
 You can work with [embedded replicas](/features/embedded-replicas) that can sync from the remote database to a local SQLite file, and delegate writes to the remote primary database:
 
@@ -42,6 +129,12 @@ conn.sync()
 ```
 
 ## Encryption
+
+<Warning>
+
+For new projects, we recommend [`pyturso`](#pyturso) for local encryption — it is built on the Turso Database engine with better performance and concurrent write support.
+
+</Warning>
 
 To enable encryption on a SQLite file, pass the encryption secret to the `encryption_key` option:
 

--- a/sdk/ts/orm/drizzle.mdx
+++ b/sdk/ts/orm/drizzle.mdx
@@ -6,6 +6,12 @@ description: Configure Drizzle to work with Turso
 
 ![Drizzle banner](/images/guides/drizzle-banner.png)
 
+<Info>
+
+Drizzle uses `@libsql/client` for Turso integration. There is also [beta support for `@tursodatabase/database`](https://orm.drizzle.team/docs/connect-turso-database) for local/embedded use cases.
+
+</Info>
+
 ## Prerequisites
 
 Before you start, make sure you:

--- a/sdk/ts/quickstart.mdx
+++ b/sdk/ts/quickstart.mdx
@@ -4,11 +4,88 @@ sidebarTitle: Quickstart
 description: Get started with Turso and TypeScript in a few simple steps.
 ---
 
-In this quickstart we will learn how to:
+In this TypeScript quickstart we will learn how to:
 
-- Retrieve database credentials
-- Connect to a remote Turso database
+- Install the Turso package
+- Connect to a local or remote database
 - Execute a query using SQL
+- Sync changes to the cloud
+
+## Recommended: @tursodatabase/database (Local / Embedded)
+
+`@tursodatabase/database` is the recommended package for local and embedded use cases (Node.js, Electron, mobile, IoT). It is built on the Turso Database engine — a ground-up rewrite of SQLite with concurrent writes (MVCC) and async I/O.
+
+<Steps>
+  <Step title="Install">
+
+```bash
+npm install @tursodatabase/database
+```
+
+  </Step>
+  <Step title="Connect">
+
+```ts
+import { connect } from "@tursodatabase/database";
+
+const db = await connect("app.db");
+```
+
+  </Step>
+  <Step title="Execute">
+
+```ts
+const createTable = db.prepare(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL
+  )
+`);
+await createTable.run();
+
+const insertUser = db.prepare("INSERT INTO users (username) VALUES (?)");
+await insertUser.run("alice");
+
+const stmt = db.prepare("SELECT * FROM users");
+const users = await stmt.all();
+console.log(users);
+```
+
+  </Step>
+  <Step title="Sync (push and pull)">
+
+If you need to sync your local database with Turso Cloud, use [`@tursodatabase/sync`](/sync/usage):
+
+```bash
+npm install @tursodatabase/sync
+```
+
+```ts
+import { connect } from "@tursodatabase/sync";
+
+const db = await connect({
+  path: "./app.db",
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+await db.exec("INSERT INTO users (username) VALUES ('bob')");
+
+// Push local writes to Turso Cloud
+await db.push();
+
+// Pull remote changes to local database
+const changed = await db.pull();
+```
+
+All reads and writes happen against the local database file — fast, offline-capable. `push()` sends your changes to the cloud. `pull()` brings remote changes down. See [Turso Sync](/sync/usage) for details on conflict resolution, checkpointing, and more.
+
+  </Step>
+</Steps>
+
+## Recommended: @tursodatabase/serverless (Remote / Over-the-Wire)
+
+`@tursodatabase/serverless` is the recommended package for **any application that connects to a remote Turso Cloud database over the network** — including Node.js servers, Docker containers, serverless functions, and edge runtimes (Cloudflare Workers, Vercel Edge, Deno Deploy). It uses only `fetch` — zero native dependencies, works everywhere.
 
 <Steps>
   <Step title="Retrieve database credentials">
@@ -20,107 +97,73 @@ You will need an existing database to continue. If you don't have one, [create o
 <Info>You will want to store these as environment variables.</Info>
 
   </Step>
-
   <Step title="Install">
 
-<Tabs>
-  <Tab title="@tursodatabase/serverless">
-
-  ```bash
-  npm install @tursodatabase/serverless
-  ```
-
-  </Tab>
-  <Tab title="@libsql/client">
-
-  <Snippet file="install-libsql-client-ts.mdx" />
-
-  </Tab>
-</Tabs>
+```bash
+npm install @tursodatabase/serverless
+```
 
   </Step>
   <Step title="Connect to your database">
 
-<Tabs>
-  <Tab title="@tursodatabase/serverless">
+```ts
+import { connect } from "@tursodatabase/serverless";
 
-  ```ts
-  import { connect } from "@tursodatabase/serverless";
+const conn = connect({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+```
 
-  const conn = connect({
-    url: process.env.TURSO_DATABASE_URL,
-    authToken: process.env.TURSO_AUTH_TOKEN,
-  });
-  ```
+For compatibility with the `@libsql/client` API, use the compat module:
 
-  For compatibility with the `@libsql/client` API, use the compat module:
+```ts
+import { createClient } from "@tursodatabase/serverless/compat";
 
-  ```ts
-  import { createClient } from "@tursodatabase/serverless/compat";
-
-  const client = createClient({
-    url: process.env.TURSO_DATABASE_URL,
-    authToken: process.env.TURSO_AUTH_TOKEN,
-  });
-  ```
-
-  </Tab>
-  <Tab title="@libsql/client">
-
-  <Snippet file="configure-libsql-client-ts.mdx" />
-
-  </Tab>
-</Tabs>
+const client = createClient({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+```
 
   </Step>
   <Step title="Execute a query using SQL">
 
-<Tabs>
-  <Tab title="@tursodatabase/serverless">
+```ts
+const stmt = await conn.prepare("SELECT * FROM users");
+const rows = await stmt.all();
+```
 
-  ```ts
-  const stmt = conn.prepare("SELECT * FROM users");
-  const rows = await stmt.all();
-  ```
+If you need to use placeholders for values, you can do that:
 
-  If you need to use placeholders for values, you can do that:
+```ts
+const stmt = await conn.prepare("SELECT * FROM users WHERE id = ?");
+const row = await stmt.get([1]);
+```
 
-  ```ts
-  const stmt = conn.prepare("SELECT * FROM users WHERE id = ?");
-  const row = await stmt.get([1]);
-  ```
+  </Step>
+</Steps>
 
-  </Tab>
-  <Tab title="@libsql/client">
+## @libsql/client (ORM & Legacy)
 
-  You can execute a SQL query against your existing database by calling `execute()`:
+Use `@libsql/client` for ORM integration (Drizzle, Prisma) or if you have an existing codebase built on it. See the [reference](/sdk/ts/reference#libsql-client-legacy) for full documentation.
 
-  ```ts
-  await turso.execute("SELECT * FROM users");
-  ```
+<Steps>
+  <Step title="Install">
 
-  If you need to use placeholders for values, you can do that:
+<Snippet file="install-libsql-client-ts.mdx" />
 
-  <CodeGroup>
+  </Step>
+  <Step title="Connect">
 
-  ```ts Positional
-  await turso.execute({
-    sql: "SELECT * FROM users WHERE id = ?",
-    args: [1],
-  });
-  ```
+<Snippet file="configure-libsql-client-ts.mdx" />
 
-  ```ts Named
-  await turso.execute({
-    sql: "INSERT INTO users VALUES (:name)",
-    args: { name: "Iku" },
-  });
-  ```
+  </Step>
+  <Step title="Execute">
 
-  </CodeGroup>
-
-  </Tab>
-</Tabs>
+```ts
+await turso.execute("SELECT * FROM users");
+```
 
   </Step>
   <Step title="Sync">

--- a/sdk/ts/reference.mdx
+++ b/sdk/ts/reference.mdx
@@ -3,16 +3,18 @@ title: Reference
 description: TypeScript Reference for Turso
 ---
 
-Turso offers two TypeScript packages for connecting to databases over HTTP:
+Turso offers three TypeScript packages:
 
-| | `@tursodatabase/serverless` | `@libsql/client` |
-| --- | --- | --- |
-| **Status** | Production-ready | Production-ready |
-| **Dependencies** | Uses only `fetch` — zero native dependencies | Requires Node.js or `/web` subpath |
-| **Concurrent writes** | Planned | Will not be supported |
-| **ORM support** | Not yet supported | Drizzle, Prisma, and others |
+| | `@tursodatabase/database` | `@tursodatabase/sync` | `@tursodatabase/serverless` | `@libsql/client` (legacy) |
+| --- | --- | --- | --- | --- |
+| **Use case** | Local / embedded database | Local database + cloud sync | Remote access (servers, containers, serverless, edge) | Legacy — ORM support |
+| **Engine** | Turso Database (rewrite) | Turso Database (rewrite) | Turso Database | libSQL (SQLite fork) |
+| **Dependencies** | Native (Node.js, WASM) | Native (Node.js) | `fetch` only — zero native deps | Requires Node.js or `/web` subpath |
+| **Concurrent writes** | Yes (MVCC) | Yes (MVCC) | Planned | Not supported |
+| **Sync** | — | push/pull (true local-first) | — | Embedded replicas (writes go to remote) |
+| **ORM support** | Drizzle (beta) | — | — | Drizzle, Prisma, and others |
 
-**`@tursodatabase/serverless`** is the lightest option with zero native dependencies — and will be the driver to later support concurrent writes. Use **`@libsql/client`** if you need a battle-tested driver today with ORM integration.
+**Starting a new project?** Use `@tursodatabase/database` for local/embedded use, `@tursodatabase/sync` for local + cloud sync, or `@tursodatabase/serverless` for any application that connects to a remote Turso Cloud database (Node.js servers, Docker containers, serverless functions, edge runtimes). **Using an ORM?** Use `@libsql/client` — it's production-ready and supported by Drizzle, Prisma, and others. Drizzle has [beta support](https://orm.drizzle.team/docs/connect-turso-database) for `@tursodatabase/database` for local/embedded use.
 
 The following runtime environments are known to be compatible:
 
@@ -21,59 +23,181 @@ The following runtime environments are known to be compatible:
 - CloudFlare Workers
 - Netlify & Vercel Edge Functions
 
-## Installing
+## @tursodatabase/database
 
-<Tabs>
-  <Tab title="@tursodatabase/serverless">
+For local and embedded use. Built on the Turso Database engine with concurrent writes (MVCC) and async I/O.
 
-  ```bash
-  npm install @tursodatabase/serverless
-  ```
+### Installing
 
-  </Tab>
-  <Tab title="@libsql/client">
+```bash
+npm install @tursodatabase/database
+```
 
-  <Snippet file="install-libsql-client-ts.mdx" />
+### Initializing
 
-  </Tab>
-</Tabs>
+```ts
+import { connect } from "@tursodatabase/database";
 
-## Initializing
+const db = await connect("app.db");
+```
 
-<Tabs>
-  <Tab title="@tursodatabase/serverless">
+In-memory databases are also supported:
 
-  Import `connect` to initialize a connection that you can use to query your database:
+```ts
+const db = await connect(":memory:");
+```
 
-  ```ts
-  import { connect } from "@tursodatabase/serverless";
+### Querying
 
-  const conn = connect({
-    url: process.env.TURSO_DATABASE_URL,
-    authToken: process.env.TURSO_AUTH_TOKEN,
-  });
-  ```
+```ts
+const stmt = db.prepare("SELECT * FROM users");
+const users = await stmt.all();
 
-  For compatibility with the `@libsql/client` API, use the compat module:
+const insert = db.prepare("INSERT INTO users (username) VALUES (?)");
+await insert.run("alice");
+```
 
-  ```ts
-  import { createClient } from "@tursodatabase/serverless/compat";
+### Encryption
 
-  const client = createClient({
-    url: process.env.TURSO_DATABASE_URL,
-    authToken: process.env.TURSO_AUTH_TOKEN,
-  });
-  ```
+Encrypt local databases at rest using the `encryption` option:
 
-  </Tab>
-  <Tab title="@libsql/client">
+```ts
+import { connect } from "@tursodatabase/database";
 
-  Import `createClient` to initialize a client that you can use to query your database:
+const db = await connect("encrypted.db", {
+  encryption: {
+    cipher: "aegis256",
+    hexkey: "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327",
+  },
+});
+```
 
-  <Snippet file="configure-libsql-client-ts.mdx" />
+Supported ciphers: `aegis256`, `aegis256x2`, `aegis128l`, `aegis128x2`, `aegis128x4`, `aes256gcm`, `aes128gcm`.
 
-  </Tab>
-</Tabs>
+Encrypted databases cannot be read as standard SQLite databases — you must use the Turso Database engine to open them.
+
+<Info>
+
+Turso Cloud databases can also be encrypted with bring-your-own-key — [learn more](/cloud/encryption).
+
+</Info>
+
+## @tursodatabase/sync
+
+For local database with cloud sync. All reads and writes happen locally; use `push()` to send changes to the cloud and `pull()` to fetch remote changes.
+
+### Installing
+
+```bash
+npm install @tursodatabase/sync
+```
+
+### Initializing
+
+```ts
+import { connect } from "@tursodatabase/sync";
+
+const db = await connect({
+  path: "./app.db",
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+```
+
+On the first run, the local database is automatically bootstrapped from the remote. See [Turso Sync](/sync/usage) for full details.
+
+### Push and Pull
+
+```ts
+// Push local writes to Turso Cloud
+await db.push();
+
+// Pull remote changes to local database
+const changed = await db.pull();
+```
+
+### Checkpoint
+
+Compact the local WAL to bound disk usage while preserving sync state:
+
+```ts
+await db.checkpoint();
+```
+
+### Stats
+
+```ts
+const s = await db.stats();
+console.info({
+  cdcOperations: s.cdcOperations,
+  mainWalSize: s.mainWalSize,
+  networkReceivedBytes: s.networkReceivedBytes,
+  networkSentBytes: s.networkSentBytes,
+  lastPullUnixTime: s.lastPullUnixTime,
+  lastPushUnixTime: s.lastPushUnixTime,
+  revision: s.revision,
+});
+```
+
+## @tursodatabase/serverless
+
+The recommended package for **any application that connects to a remote Turso Cloud database** — Node.js servers, Docker containers, serverless functions (AWS Lambda, Vercel Functions), and edge runtimes (Cloudflare Workers, Deno Deploy). Uses only `fetch` — zero native dependencies, works everywhere `fetch` is available.
+
+### Installing
+
+```bash
+npm install @tursodatabase/serverless
+```
+
+### Initializing
+
+```ts
+import { connect } from "@tursodatabase/serverless";
+
+const conn = connect({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+```
+
+For compatibility with the `@libsql/client` API, use the compat module:
+
+```ts
+import { createClient } from "@tursodatabase/serverless/compat";
+
+const client = createClient({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+```
+
+### Querying
+
+```ts
+const stmt = await conn.prepare("SELECT * FROM users");
+const rows = await stmt.all();
+
+const stmt2 = await conn.prepare("SELECT * FROM users WHERE id = ?");
+const row = await stmt2.get([1]);
+```
+
+## @libsql/client (Legacy)
+
+The `@libsql/client` package is built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. It is fully supported and battle-tested — if you run into something that doesn't work yet with the newer Turso packages, `@libsql/client` is a reliable fallback. It's also the right choice if you need ORM integration beyond Drizzle (e.g., Prisma) or are working with an existing `@libsql/client`-based codebase.
+
+<Info>
+
+With `@libsql/client` embedded replicas, reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use `@tursodatabase/sync` with [Turso Sync](/sync/usage).
+
+</Info>
+
+### Installing
+
+<Snippet file="install-libsql-client-ts.mdx" />
+
+### Initializing
+
+<Snippet file="configure-libsql-client-ts.mdx" />
 
 <br />
 
@@ -83,9 +207,7 @@ If you're using libsql locally or an sqlite file, you can ignore passing `authTo
 
 </Info>
 
-## In-Memory Databases
-
-libSQL supports connecting to [in-memory databases](https://www.sqlite.org/inmemorydb.html) for cases where you don't require persistence:
+### In-Memory Databases
 
 ```ts {4}
 import { createClient } from "@libsql/client";
@@ -95,7 +217,7 @@ const client = createClient({
 });
 ```
 
-## Local Development
+### Local Development
 
 You can work locally using an SQLite file and passing the path to `createClient`:
 
@@ -114,7 +236,13 @@ The `@libsql/client/web` does not support local file URLs.
 
 </Warning>
 
-## Embedded Replicas
+### Embedded Replicas
+
+<Warning>
+
+For new projects, we recommend [`@tursodatabase/sync`](#tursodatabasesync) for sync use cases — it is built on the Turso Database engine with better performance, true local-first writes, and concurrent write support.
+
+</Warning>
 
 You can work with embedded replicas by passing your Turso Database URL to `syncUrl`:
 
@@ -130,17 +258,13 @@ const client = createClient({
 
 <Snippet file="embedded-replicas-warning.mdx" />
 
-### Manual Sync
-
-The `sync()` function allows you to sync manually the local database with the remote counterpart:
+#### Manual Sync
 
 ```ts
 await client.sync();
 ```
 
-### Periodic Sync
-
-You can automatically sync at intervals by configuring the `syncInterval` (seconds) property when instantiating a new libSQL client:
+#### Periodic Sync
 
 ```ts {6}
 import { createClient } from "@libsql/client";
@@ -153,19 +277,21 @@ const client = createClient({
 });
 ```
 
-## Encryption
+### Encryption
 
-To enable encryption on a SQLite file, pass the `encryptionKey`:
+<Warning>
+
+For new projects, we recommend [`@tursodatabase/database`](#tursodatabasedatabase) for local encryption — it is built on the Turso Database engine with better performance and concurrent write support.
+
+</Warning>
 
 <Snippet file="encryption-at-rest-typescript.mdx" />
 
 Encrypted databases appear as raw data and cannot be read as standard SQLite databases. You must use the libSQL client for any operations &mdash; [learn more](/libsql#encryption-at-rest).
 
-## Concurrency
+### Concurrency
 
-By default, the client performs up to `20` concurrent requests. You can set this option to a higher
-number to increase the concurrency limit. You can also set this option to `undefined` to disable concurrency
-completely:
+By default, the client performs up to `20` concurrent requests:
 
 ```ts {4}
 import { createClient } from "@libsql/client";
@@ -175,7 +301,7 @@ const client = createClient({
 });
 ```
 
-## Response
+### Response
 
 Each method listed below returns a `Promise<ResultSet>`:
 
@@ -186,7 +312,7 @@ Each method listed below returns a `Promise<ResultSet>`:
 | `rowsAffected`    | `number`                      | The number of rows affected by a write statement, `0` otherwise                                                    |
 | `lastInsertRowid` | `bigint         \| undefined` | The ID of a newly inserted row, or `undefined` if there is none for the statement                                  |
 
-## Simple query
+### Simple query
 
 You can pass a string or object to `execute()` to invoke a SQL statement:
 
@@ -205,7 +331,7 @@ const result = await client.execute({
 
 </CodeGroup>
 
-## Placeholders
+### Placeholders
 
 libSQL supports the use of positional and named placeholders within SQL statements:
 
@@ -255,7 +381,7 @@ libSQL supports the same named placeholder characters as SQLite &mdash; `:`, `@`
 
 </Info>
 
-## Transaction Modes
+### Transaction Modes
 
 | Mode       | SQLite command               | Description                                                                                                                                                                                        |
 | ---------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -263,7 +389,7 @@ libSQL supports the same named placeholder characters as SQLite &mdash; `:`, `@`
 | `read`     | `BEGIN TRANSACTION READONLY` | The transaction may only execute statements that read data (select). Read transactions can occur on replicas, and can operate in parallel with other read transactions.                            |
 | `deferred` | `BEGIN DEFERRED`             | The transaction starts in read mode, then changes to write as soon as a write statement is executed. This mode change may fail if there is a write transaction currently executing on the primary. |
 
-## Batch Transactions
+### Batch Transactions
 
 A batch consists of multiple SQL statements executed sequentially within an implicit transaction. The backend handles the transaction: success commits all changes, while any failure results in a full rollback with no modifications.
 
@@ -283,7 +409,7 @@ const result = await client.batch(
 );
 ```
 
-## Interactive Transactions
+### Interactive Transactions
 
 Interactive transactions in SQLite ensure the consistency of a series of read and write operations within a transaction's scope. These transactions give you control over when to commit or roll back changes, isolating them from other client activity.
 
@@ -394,7 +520,7 @@ try {
   on high-latency or busy databases.
 </Warning>
 
-## ATTACH
+### ATTACH
 
 You can attach multiple databases to the current connection using the `ATTACH` attachment:
 


### PR DESCRIPTION
- Add package decision table to introduction.mdx (with libsql for Python remote)
- Add @tursodatabase/database, sync, serverless sections to reference.mdx
- Move @libsql/client to Legacy section in reference.mdx
- Restructure TS quickstart to lead with database (local) then serverless (remote)
- Fix async await on database prepare().run()/all() and serverless conn.prepare()
- Rewrite Python quickstart: lead with pyturso, add turso.sync, add libsql remote
- Use uv as primary install method in Python quickstart
- Note Drizzle ORM support for @tursodatabase/database
- Add context about libSQL as battle-tested fallback