### PR TITLE
Improve @tursodatabase/api SDK discoverability across Platform API docs

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,17 +1,81 @@
 ---
 sidebarTitle: Introduction
 title: Turso Platform API
-description:
+description: Programmatically manage databases, groups, organizations, and tokens with the Turso Platform API.
 ---
 
-The Turso API gives you everything needed to manage your organization and its members, groups, databases, and API tokens.
+## Quickstart with the TypeScript SDK
 
-If you want to programatically create and manage databases, either for building a platform where you provide SQLite databases to your users or have a per-user SQLite database architecture, this is the API to do that.
+The fastest way to use the Platform API from JavaScript or TypeScript is the official [`@tursodatabase/api`](https://www.npmjs.com/package/@tursodatabase/api) client:
+
+```bash
+npm install @tursodatabase/api
+```
+
+```ts
+import { createClient } from "@tursodatabase/api";
+
+const turso = createClient({
+  org: process.env.TURSO_ORG!,
+  token: process.env.TURSO_PLATFORM_TOKEN!,
+});
+
+// Create a database
+const db = await turso.databases.create("user-abc123", { group: "default" });
+
+// Generate a scoped auth token for that database
+const { jwt } = await turso.databases.createToken("user-abc123");
+
+// Delete it when no longer needed
+await turso.databases.delete("user-abc123");
+```
+
+For the raw HTTP reference, see the resource endpoints below.
+
+## Common use cases
+
+### Database per user / database per agent (multi-tenant)
+
+Provision a dedicated database per user or per AI agent. Each entity gets its own isolated SQLite database that you create, token-scope, and tear down via the API.
+
+```ts
+import { createClient } from "@tursodatabase/api";
+
+const turso = createClient({
+  org: process.env.TURSO_ORG!,
+  token: process.env.TURSO_PLATFORM_TOKEN!,
+});
+
+// On user signup or agent creation — provision a database
+const db = await turso.databases.create(`agent-${agentId}`, { group: "default" });
+
+// Generate a scoped token for that database
+const { jwt } = await turso.databases.createToken(`agent-${agentId}`);
+
+// Store db.hostname and jwt for the session
+```
+
+Once the database is created, connect to it from your application:
+
+- **Over the wire** — query the database remotely using [`@tursodatabase/serverless`](/sdk/ts/quickstart)
+- **Local-first with sync** — sync the database to and from a local file using [`@tursodatabase/sync`](/sync/usage)
+
+### Platform / reseller
+
+Create and manage databases on behalf of your end users. Use the Platform API to build your own database-as-a-service on top of Turso.
+
+```ts
+// List all databases in your organization
+const databases = await turso.databases.list();
+
+// Get details for a specific database
+const db = await turso.databases.get("customer-db");
+```
 
 <CardGroup cols={2}>
 
 <Card title="API Quickstart" icon="play" href="/api-reference/quickstart">
-  Get started with the Turso API to create your first database.
+  Step-by-step guide to create your first database with the API.
 </Card>
 
 </CardGroup>

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -3,6 +3,10 @@ title: Quickstart
 description: Get started with Turso API in a few easy steps.
 ---
 
+<Info>
+  **Using TypeScript?** You can skip the raw HTTP examples and use the [`@tursodatabase/api`](https://www.npmjs.com/package/@tursodatabase/api) client instead. See the [SDK quickstart](/api-reference/introduction#quickstart-with-the-typescript-sdk).
+</Info>
+
 <Steps>
 
 <Step title="Signup or Login using the Turso CLI">

--- a/features/embedded-replicas/introduction.mdx
+++ b/features/embedded-replicas/introduction.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Introduction
 ---
 
 <Warning>
-  Embedded Replicas are a legacy Turso Cloud feature built on [libSQL](/libsql). **Writes are sent to the remote primary database, not stored locally.** For new projects that need sync, use [Turso Sync](/sync/usage), which is built on the Turso Database engine and provides true local-first reads and writes with explicit push/pull.
+  Embedded Replicas are a legacy Turso Cloud feature built on [libSQL](/libsql). **Writes are sent to the remote primary database, not stored locally.** For new projects that need sync, use [Turso Sync](/sync/usage), which is built on the Turso Database engine and provides true local-first reads and writes with explicit push/pull. For offline-first writes (the equivalent of `offline: true`), see [Offline-first writes](/sync/usage#offline-first-writes).
 </Warning>
 
 Turso Cloud's embedded replicas let you replicate a database right within your application. This is especially useful for VMs or VPS deployments, and for mobile applications where stable connectivity is a challenge, since they allow uninterrupted access to the local database.

--- a/features/multi-db-schemas.mdx
+++ b/features/multi-db-schemas.mdx
@@ -12,6 +12,10 @@ description: Create and share a single schema across multiple databases.
 Turso allows you to create a single schema and share it across multiple databases. This is useful for creating a multi-tenant application where each tenant has their own database.
 
 <Info>
+  **Using TypeScript?** To provision databases programmatically, use the [`@tursodatabase/api`](https://www.npmjs.com/package/@tursodatabase/api) client rather than calling the REST API directly. See the [SDK quickstart](/api-reference/introduction#quickstart-with-the-typescript-sdk).
+</Info>
+
+<Info>
 
 Try the [Turso Per User Starter](https://github.com/notrab/turso-per-user-starter) to get started with a multi-tenant application using Next.js, Drizzle, Clerk, libSQL, and Turso Multi-DB Schemas.
 

--- a/features/platform-api.mdx
+++ b/features/platform-api.mdx
@@ -5,7 +5,11 @@ description: Manage databases, and teams with the Turso Platform API.
 
 The Turso [Platform API](/api-reference) is a RESTful API that allows you to manage databases, and users. It is the same API that is used by the Turso Platform Web UI and [CLI](/cli).
 
-The API is built for platforms that want to integrate with Turso to provide their users a serverless SQLite database.
+The API is built for platforms that want to integrate with Turso to provide their users a serverless SQLite database — whether you're building a database-per-user (multi-tenant) architecture or a platform/reseller that provisions databases on behalf of end users.
+
+<Info>
+  **Using TypeScript?** The [`@tursodatabase/api`](https://www.npmjs.com/package/@tursodatabase/api) client wraps the entire Platform API. See the [SDK quickstart](/api-reference/introduction#quickstart-with-the-typescript-sdk).
+</Info>
 
 You can create databases, [database branches](/features/branching), [recover databases](/features/point-in-time-recovery) from a point in time, as well as [manage teams](/features/organizations), API tokens, and more with the Turso Platform API.
 

--- a/sync/usage.mdx
+++ b/sync/usage.mdx
@@ -243,3 +243,105 @@ log.Printf("stats: cdc=%v, main=%d revert=%d rx=%d tx=%d pull=%d push=%d revisio
 </Step>
 
 </Steps>
+
+## Offline-first writes
+
+If your app needs to accept writes without internet connectivity, write locally and call `push()` when the connection is available. All changes are safely stored in the local database file until they can be synced.
+
+<CodeGroup>
+
+```ts TypeScript
+import { connect } from '@tursodatabase/sync';
+
+// bootstrapIfEmpty: false lets the app start offline without
+// needing to reach the remote on first launch
+const db = await connect({
+  path: './local.db',
+  url: process.env.TURSO_URL!,
+  authToken: process.env.TURSO_AUTH_TOKEN!,
+  bootstrapIfEmpty: false,
+});
+
+async function syncWhenOnline(db) {
+  try {
+    await db.push();
+  } catch (e) {
+    // No connectivity — changes are safe in the local file
+    // and will sync on the next push() call
+  }
+}
+
+// On app launch, pull the latest state if online
+try {
+  await db.pull();
+} catch (e) {
+  // Offline — local data is still available for reads and writes
+}
+
+// On a timer or connectivity event
+await syncWhenOnline(db);
+```
+
+```py Python
+import os
+import turso.sync
+
+# bootstrap_if_empty=False lets the app start offline without
+# needing to reach the remote on first launch
+conn = turso.sync.connect(
+    path="./local.db",
+    remote_url=os.environ["TURSO_URL"],
+    remote_auth_token=os.environ["TURSO_AUTH_TOKEN"],
+    bootstrap_if_empty=False,
+)
+
+def sync_when_online(conn):
+    try:
+        conn.push()
+    except Exception:
+        # No connectivity — changes are safe in the local file
+        # and will sync on the next push() call
+        pass
+
+# On app launch, pull the latest state if online
+try:
+    conn.pull()
+except Exception:
+    # Offline — local data is still available for reads and writes
+    pass
+
+# On a timer or connectivity event
+sync_when_online(conn)
+```
+
+```go Go
+// BootstrapIfEmpty: false lets the app start offline without
+// needing to reach the remote on first launch
+db, err := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{
+	Path:             "./local.db",
+	RemoteUrl:        os.Getenv("TURSO_URL"),
+	RemoteAuthToken:  os.Getenv("TURSO_AUTH_TOKEN"),
+	BootstrapIfEmpty: false,
+})
+
+func syncWhenOnline(ctx context.Context, db *turso.TursoSyncDb) {
+	if err := db.Push(ctx); err != nil {
+		// No connectivity — changes are safe in the local file
+		// and will sync on the next Push() call
+		log.Println("push deferred:", err)
+	}
+}
+
+// On app launch, pull the latest state if online
+if _, err := db.Pull(ctx); err != nil {
+	// Offline — local data is still available for reads and writes
+	log.Println("pull deferred:", err)
+}
+
+// On a timer or connectivity event
+syncWhenOnline(ctx, db)
+```
+
+</CodeGroup>
+
+This replaces the `offline: true` flag from the legacy [`@libsql/client` embedded replicas](/features/embedded-replicas/introduction) API. With Turso Sync, all reads and writes happen locally by default — you control when to sync with explicit `push()` and `pull()` calls.


### PR DESCRIPTION
LLMs and developers landing on the Platform API pages were defaulting to raw HTTP calls because the SDK was never surfaced. This change:

- Leads the API introduction with a TypeScript SDK quickstart and use-case headings ("database per user", "database per agent", "multi-tenant", "platform/reseller")
- Shows how to connect after provisioning: @tursodatabase/serverless for remote queries, @tursodatabase/sync for local-first sync
- Adds SDK callouts to the quickstart, platform-api overview, and multi-db-schemas pages
- Adds an "Offline-first writes" section to the Turso Sync usage page showing push() with connectivity detection (bridges from legacy `offline: true` flag)
- Updates the embedded replicas deprecation notice to link directly to the offline-first writes pattern