### PR TITLE
Document per-org MFA enforcement

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1275,6 +1275,10 @@
                   "overages": {
                     "type": "boolean",
                     "description": "Enable or disable overages for the organization."
+                  },
+                  "require_mfa": {
+                    "type": "boolean",
+                    "description": "Require all members of the organization to have multi-factor authentication enabled. The requesting user must have MFA enabled on their own account before enabling this requirement."
                   }
                 }
               }
@@ -2489,6 +2493,11 @@
             "description": "The name of the organization. Every user has a `personal` organization for their own account.",
             "example": false
           },
+          "require_mfa": {
+            "type": "boolean",
+            "description": "Whether all members of the organization are required to have multi-factor authentication enabled.",
+            "example": false
+          },
           "blocked_reads": {
             "type": "boolean",
             "description": "Returns the current status for blocked reads.",
@@ -2598,7 +2607,8 @@
               "type": "team",
               "overages": false,
               "blocked_reads": false,
-              "blocked_writes": false
+              "blocked_writes": false,
+              "require_mfa": false
             }
           },
           "Accepted": {

--- a/api-reference/organizations/update.mdx
+++ b/api-reference/organizations/update.mdx
@@ -5,12 +5,21 @@ openapi: "PATCH /v1/organizations/{organizationSlug}"
 
 <RequestExample>
 
-```bash cURL
+```bash cURL (overages)
 curl -L -X PATCH https://api.turso.tech/v1/organizations/{organizationSlug} \
   -H 'Authorization: Bearer TOKEN' \
   -H 'Content-Type: application/json' \
   -d '{
       "overages": true
+  }'
+```
+
+```bash cURL (require MFA)
+curl -L -X PATCH https://api.turso.tech/v1/organizations/{organizationSlug} \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+      "require_mfa": true
   }'
 ```
 


### PR DESCRIPTION
## Summary

- Adds `require_mfa` field to the Organization update endpoint request body schema
- Adds `require_mfa` field to the Organization model schema with description and example
- Adds a cURL example for enabling MFA enforcement on the update endpoint page

Matches the new per-org MFA enforcement feature added in [turso-platform#3659](https://github.com/chiselstrike/turso-platform/pull/3659).

## Test plan

- [ ] Verify the update endpoint page renders both cURL examples (overages + require MFA)
- [ ] Verify `require_mfa` appears in the Organization schema docs
- [ ] Verify the Organization example object includes `require_mfa: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)