### PR TITLE
document username parameter for v2 invite endpoint

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2273,7 +2273,7 @@
           }
         ],
         "requestBody": {
-          "description": "The user you want to invite to join Turso, and your organization.",
+          "description": "The user you want to invite to join Turso, and your organization. Provide exactly one of email or username.",
           "required": true,
           "content": {
             "application/json": {
@@ -2282,7 +2282,11 @@
                 "properties": {
                   "email": {
                     "type": "string",
-                    "description": "The email of the user you want to invite."
+                    "description": "The email of the user you want to invite. Exactly one of email or username must be provided."
+                  },
+                  "username": {
+                    "type": "string",
+                    "description": "The username of an existing Turso user you want to invite. Exactly one of email or username must be provided."
                   },
                   "role": {
                     "type": "string",
@@ -2294,10 +2298,7 @@
                     "description": "The role given to the user.",
                     "default": "member"
                   }
-                },
-                "required": [
-                  "email"
-                ]
+                }
               }
             }
           }

--- a/api-reference/organizations/invites/create-v2.mdx
+++ b/api-reference/organizations/invites/create-v2.mdx
@@ -5,7 +5,7 @@ openapi: "POST /v2/organizations/{organizationSlug}/invites"
 
 <Info>
 
-If you want to invite someone who is already a registered Turso user, you can [add them](/api-reference/organizations/members/add) instead.
+You can invite by **email** or by **username** — provide exactly one. When inviting by username, the invite is sent to that user's registered email.
 
 </Info>
 
@@ -23,11 +23,18 @@ If a pending invite already exists for the same email, it will be replaced with 
 
 <RequestExample>
 
-```bash cURL
+```bash Invite by email
 curl -L -X POST https://api.turso.tech/v2/organizations/{organizationSlug}/invites \
   -H 'Authorization: Bearer TOKEN' \
   -H 'Content-Type: application/json' \
   -d '{"email": "user@example.com", "role": "member"}'
+```
+
+```bash Invite by username
+curl -L -X POST https://api.turso.tech/v2/organizations/{organizationSlug}/invites \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "turso-user", "role": "member"}'
 ```
 
 ```ts Node.js


### PR DESCRIPTION
The v2 invite endpoint now accepts either email or username. Update the OpenAPI spec and create-v2 docs to reflect this.