### PR TITLE
Extreme makeover on Rust and Go docs

### DIFF
--- a/_snippets/encryption-at-rest-golang.mdx
+++ b/_snippets/encryption-at-rest-golang.mdx
@@ -25,9 +25,9 @@ func main() {
 
     dbPath := filepath.Join(dir, dbName)
 
-    connector, err := NewEmbeddedReplicaConnector(dbPath, primaryUrl,
-        WithAuthToken(authToken),
-        WithEncryption(encryptionKey),
+    connector, err := libsql.NewEmbeddedReplicaConnector(dbPath, primaryUrl,
+        libsql.WithAuthToken(authToken),
+        libsql.WithEncryption(encryptionKey),
     )
     if err != nil {
         fmt.Println("Error creating connector:", err)

--- a/connect/go.mdx
+++ b/connect/go.mdx
@@ -11,7 +11,6 @@ Add the Turso package to your Go project:
 
 ```bash
 go get turso.tech/database/tursogo
-go install turso.tech/database/tursogo
 ```
 
 </Step>
@@ -26,12 +25,15 @@ package main
 import (
     "database/sql"
     "fmt"
-    _ "github.com/tursodatabase/turso-go"
+    _ "turso.tech/database/tursogo"
 )
 
 func main() {
-    conn, _ := sql.Open("turso", "sqlite.db")
-    defer conn.Close()
+    db, err := sql.Open("turso", "sqlite.db")
+    if err != nil {
+        panic(err)
+    }
+    defer db.Close()
 }
 ```
 
@@ -42,7 +44,7 @@ func main() {
 Create a table for users:
 
 ```go
-_, err := conn.Exec(`
+_, err = db.Exec(`
   CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL
@@ -60,12 +62,12 @@ if err != nil {
 Insert some data into the users table:
 
 ```go
-_, err = conn.Exec("INSERT INTO users (username) VALUES (?)", "alice")
+_, err = db.Exec("INSERT INTO users (username) VALUES (?)", "alice")
 if err != nil {
     panic(err)
 }
 
-_, err = conn.Exec("INSERT INTO users (username) VALUES (?)", "bob")
+_, err = db.Exec("INSERT INTO users (username) VALUES (?)", "bob")
 if err != nil {
     panic(err)
 }
@@ -78,14 +80,18 @@ if err != nil {
 Query all users from the table:
 
 ```go
-stmt, _ := conn.Prepare("SELECT * FROM users")
-defer stmt.Close()
+rows, err := db.Query("SELECT * FROM users")
+if err != nil {
+    panic(err)
+}
+defer rows.Close()
 
-rows, _ := stmt.Query()
 for rows.Next() {
     var id int
     var username string
-    _ = rows.Scan(&id, &username)
+    if err := rows.Scan(&id, &username); err != nil {
+        panic(err)
+    }
     fmt.Printf("User: ID: %d, Username: %s\n", id, username)
 }
 ```

--- a/sdk/go/quickstart.mdx
+++ b/sdk/go/quickstart.mdx
@@ -1,19 +1,125 @@
 ---
 title: Turso Quickstart (Go)
 sidebarTitle: Quickstart
-description: Get started with Turso and Go using the libSQL client in a few simple steps.
+description: Get started with Turso and Go in a few simple steps.
 ---
-
-The libSQL package is designed to work with [`database/sql`](https://pkg.go.dev/database/sql) to provide the usual methods you'd expect when working with databases in Go.
-
 
 In this Go quickstart we will learn how to:
 
-- Retrieve database credentials
-- Install Go libSQL
-- Connect to a local or remote Turso database
+- Install the Turso package
+- Connect to a local or remote database
 - Execute a query using SQL
-- Sync changes to local database
+- Sync changes to the cloud
+
+## Recommended: tursogo (Local + Cloud Sync)
+
+`tursogo` is the recommended package for running a local database, including synchronizing it to and from Turso Cloud. It is built on the Turso Database engine — a ground-up rewrite of SQLite with concurrent writes (MVCC) and async I/O. It implements the standard `database/sql` driver interface, so it works as a drop-in replacement for any Go SQLite driver. It ships prebuilt native libraries and uses [purego](https://github.com/ebitengine/purego) for FFI — no CGO required.
+
+<Steps>
+  <Step title="Install">
+
+```bash
+go get turso.tech/database/tursogo
+```
+
+  </Step>
+  <Step title="Connect">
+
+```go
+package main
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "turso.tech/database/tursogo"
+)
+
+func main() {
+	db, _ := sql.Open("turso", "app.db")
+	defer db.Close()
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS users (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL
+	)`)
+
+	db.Exec("INSERT INTO users (name) VALUES (?)", "Alice")
+
+	rows, _ := db.Query("SELECT * FROM users")
+	defer rows.Close()
+	for rows.Next() {
+		var id int
+		var name string
+		rows.Scan(&id, &name)
+		fmt.Printf("User: %d %s\n", id, name)
+	}
+}
+```
+
+  </Step>
+  <Step title="Sync (push and pull)">
+
+If you need to sync your local database with Turso Cloud, use the sync driver:
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	turso "turso.tech/database/tursogo"
+)
+
+func main() {
+	ctx := context.Background()
+
+	syncDb, _ := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{
+		Path:      "app.db",
+		RemoteUrl: os.Getenv("TURSO_DATABASE_URL"),
+		AuthToken: os.Getenv("TURSO_AUTH_TOKEN"),
+	})
+
+	db, _ := syncDb.Connect(ctx)
+	defer db.Close()
+
+	db.ExecContext(ctx, "INSERT INTO users (name) VALUES (?)", "Bob")
+
+	// Push local writes to Turso Cloud
+	syncDb.Push(ctx)
+
+	// Pull remote changes to local database
+	syncDb.Pull(ctx)
+}
+```
+
+All reads and writes happen against the local database file — fast, offline-capable. `Push()` sends your changes to the cloud. `Pull()` brings remote changes down. See the [reference](/sdk/go/reference) for checkpoint, stats, and encryption. See [Turso Sync](/sync/usage) for details on conflict resolution and more.
+
+<Info>
+
+You can test sync locally without a Turso Cloud account by starting a local sync server:
+
+```bash
+tursodb :memory: --sync-server 127.0.0.1:8080
+```
+
+Then set `RemoteUrl` to `http://127.0.0.1:8080` (no `AuthToken` needed). See [Turso Database quickstart](/tursodb/quickstart) for how to install `tursodb`.
+
+</Info>
+
+  </Step>
+</Steps>
+
+## Remote Access (Over-the-Wire)
+
+If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), use the `libsql-client-go` package. It connects to your database via the libSQL wire protocol — no local file needed, pure Go.
+
+<Info>
+
+For most applications, we recommend running a local database with sync (`NewTursoSyncDb`) instead — it gives you faster reads, offline support, and lower latency. Remote access is useful when you cannot store a local database file (e.g., stateless serverless environments).
+
+</Info>
 
 <Steps>
   <Step title="Retrieve database credentials">
@@ -25,142 +131,52 @@ You will need an existing database to continue. If you don't have one, [create o
 <Info>You will want to store these as environment variables.</Info>
 
   </Step>
-
   <Step title="Install">
 
-First begin by adding libSQL to your project:
-
-<AccordionGroup>
-  <Accordion title="Local">
-    ```bash
-    go get github.com/tursodatabase/go-libsql
-    ```
-
-  </Accordion>
-
-  <Accordion title="Remote only">
-    ```bash
-    go get github.com/tursodatabase/libsql-client-go/libsql
-    ```
-
-  </Accordion>
-
-</AccordionGroup>
-
-  </Step>
-
-  <Step title="Connect">
-
-Now connect to your local or remote database using the libSQL connector:
-
-<AccordionGroup>
-  <Accordion title="Local only">
-
-    <Info>Starting a new project? Consider using [Turso Database](/tursodb/quickstart) for Go — it offers concurrent writes, vector search, and a modern async engine built on the next evolution of SQLite.</Info>
-
-    ```go
-    package main
-
-    import (
-      "database/sql"
-      "fmt"
-      "os"
-
-      _ "github.com/tursodatabase/go-libsql"
-    )
-
-    func main() {
-      dbName := "file:./local.db"
-
-      db, err := sql.Open("libsql", dbName)
-      if err != nil {
-        fmt.Fprintf(os.Stderr, "failed to open db %s", err)
-        os.Exit(1)
-      }
-      defer db.Close()
-    }
-    ```
-
-  </Accordion>
-
-  <Accordion title="Remote only">
-    ```go
-    package main
-
-    import (
-      "database/sql"
-      "fmt"
-      "os"
-
-      _ "github.com/tursodatabase/libsql-client-go/libsql"
-    )
-
-    func main() {
-      url := "libsql://[DATABASE].turso.io?authToken=[TOKEN]"
-
-      db, err := sql.Open("libsql", url)
-      if err != nil {
-        fmt.Fprintf(os.Stderr, "failed to open db %s: %s", url, err)
-        os.Exit(1)
-      }
-      defer db.Close()
-    }
-    ```
-
-  </Accordion>
-</AccordionGroup>
-
-  </Step>
-
-  <Step title="Execute">
-
-You can execute a SQL query against your existing database. Create a function to query your database that accepts the pointer to `sql.DB` as an argument:
-
-```go
-type User struct {
-	ID   int
-	Name string
-}
-
-func queryUsers(db *sql.DB)  {
-  rows, err := db.Query("SELECT * FROM users")
-  if err != nil {
-    fmt.Fprintf(os.Stderr, "failed to execute query: %v\n", err)
-    os.Exit(1)
-  }
-  defer rows.Close()
-
-  var users []User
-
-  for rows.Next() {
-    var user User
-
-    if err := rows.Scan(&user.ID, &user.Name); err != nil {
-      fmt.Println("Error scanning row:", err)
-      return
-    }
-
-    users = append(users, user)
-    fmt.Println(user.ID, user.Name)
-  }
-
-  if err := rows.Err(); err != nil {
-    fmt.Println("Error during rows iteration:", err)
-  }
-}
-```
-
-Now inside `func main()` call `queryUsers` and pass in the pointer to `sql.DB`:
-
-```go
-queryUsers(db)
+```bash
+go get github.com/tursodatabase/libsql-client-go/libsql
 ```
 
   </Step>
+  <Step title="Connect and query">
 
-  <Step title="Sync">
+```go
+package main
 
-If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides true local-first sync with explicit `push()` and `pull()` operations.
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	_ "github.com/tursodatabase/libsql-client-go/libsql"
+)
+
+func main() {
+	url := os.Getenv("TURSO_DATABASE_URL") + "?authToken=" + os.Getenv("TURSO_AUTH_TOKEN")
+
+	db, _ := sql.Open("libsql", url)
+	defer db.Close()
+
+	rows, _ := db.Query("SELECT * FROM users")
+	defer rows.Close()
+	for rows.Next() {
+		var id int
+		var name string
+		rows.Scan(&id, &name)
+		fmt.Printf("User: %d %s\n", id, name)
+	}
+}
+```
 
   </Step>
 </Steps>
+
+## Legacy: go-libsql (Embedded Replicas)
+
+<Warning>
+
+**Usage of embedded replicas is strongly discouraged.** With embedded replicas, reads are local but **writes are sent to the remote database** — this means writes fail when offline, have higher latency, and don't support concurrent writes. Use `tursogo` with `NewTursoSyncDb` instead: all reads and writes are local, and you explicitly sync with `Push()` / `Pull()`.
+
+</Warning>
+
+See the [reference](/sdk/go/reference) for legacy documentation on embedded replicas if you have an existing `go-libsql` codebase.

--- a/sdk/go/reference.mdx
+++ b/sdk/go/reference.mdx
@@ -1,8 +1,199 @@
 ---
 title: Reference
+description: Go Reference for Turso
 ---
 
-## Embedded Replicas
+Turso offers two Go packages:
+
+| | `tursogo` | `libsql-client-go` | `go-libsql` (legacy) |
+| --- | --- | --- | --- |
+| **Use case** | Local / embedded database, sync | Remote access (over-the-wire) | Legacy — embedded replicas |
+| **Engine** | Turso Database (rewrite) | libSQL wire protocol | libSQL (SQLite fork) |
+| **Concurrent writes** | Yes (MVCC) | N/A (remote) | Not supported |
+| **Sync** | push/pull (true local-first) | — | Embedded replicas (writes go to remote) |
+| **CGO** | Not required | Not required | Required |
+| **API** | `database/sql` | `database/sql` | `database/sql` |
+
+**Starting a new project?** Use `tursogo` for local/embedded use or sync. Use `libsql-client-go` for remote access. Neither requires CGO.
+
+## tursogo
+
+For local and embedded use. Built on the Turso Database engine with concurrent writes (MVCC) and async I/O.
+
+### Installing
+
+```bash
+go get turso.tech/database/tursogo
+```
+
+### Connecting
+
+```go
+import (
+	"database/sql"
+	_ "turso.tech/database/tursogo"
+)
+
+db, err := sql.Open("turso", "app.db")
+```
+
+In-memory databases are also supported:
+
+```go
+db, err := sql.Open("turso", ":memory:")
+```
+
+### Querying
+
+```go
+_, err = db.Exec(`CREATE TABLE IF NOT EXISTS users (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL
+)`)
+
+_, err = db.Exec("INSERT INTO users (name) VALUES (?)", "Alice")
+
+rows, err := db.Query("SELECT * FROM users")
+defer rows.Close()
+
+for rows.Next() {
+	var id int
+	var name string
+	rows.Scan(&id, &name)
+	fmt.Printf("User: %d %s\n", id, name)
+}
+```
+
+### Encryption
+
+Encrypt local databases at rest using DSN options:
+
+```go
+import (
+	"database/sql"
+	"fmt"
+	_ "turso.tech/database/tursogo"
+)
+
+hexkey := "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327"
+dsn := fmt.Sprintf("encrypted.db?experimental=encryption&encryption_cipher=aegis256&encryption_hexkey=%s", hexkey)
+
+db, err := sql.Open("turso", dsn)
+```
+
+Supported ciphers: `aegis256`, `aegis256x2`, `aegis128l`, `aegis128x2`, `aegis128x4`, `aes256gcm`, `aes128gcm`.
+
+Encrypted databases cannot be read as standard SQLite databases — you must use the Turso Database engine to open them.
+
+<Info>
+
+Turso Cloud databases can also be encrypted with bring-your-own-key — [learn more](/cloud/encryption).
+
+</Info>
+
+### Sync (Push and Pull)
+
+For local database with cloud sync. All reads and writes happen locally; use `Push()` to send changes to the cloud and `Pull()` to fetch remote changes.
+
+```go
+import (
+	"context"
+	"os"
+	turso "turso.tech/database/tursogo"
+)
+
+ctx := context.Background()
+
+syncDb, err := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{
+	Path:      "app.db",
+	RemoteUrl: os.Getenv("TURSO_DATABASE_URL"),
+	AuthToken: os.Getenv("TURSO_AUTH_TOKEN"),
+})
+
+db, err := syncDb.Connect(ctx)
+```
+
+On the first run, the local database is automatically bootstrapped from the remote. See [Turso Sync](/sync/usage) for full details.
+
+#### Push and Pull
+
+```go
+// Push local writes to Turso Cloud
+err := syncDb.Push(ctx)
+
+// Pull remote changes to local database
+changed, err := syncDb.Pull(ctx)
+```
+
+#### Checkpoint
+
+Compact the local WAL to bound disk usage while preserving sync state:
+
+```go
+err := syncDb.Checkpoint(ctx)
+```
+
+#### Stats
+
+```go
+stats, err := syncDb.Stats(ctx)
+fmt.Printf("CDC operations: %d\n", stats.CdcOperations)
+fmt.Printf("Main WAL size: %d\n", stats.MainWalSize)
+fmt.Printf("Network sent: %d bytes\n", stats.NetworkSentBytes)
+fmt.Printf("Network received: %d bytes\n", stats.NetworkReceivedBytes)
+fmt.Printf("Last pull: %d\n", stats.LastPullUnixTime)
+fmt.Printf("Last push: %d\n", stats.LastPushUnixTime)
+fmt.Printf("Revision: %s\n", stats.Revision)
+```
+
+## libsql-client-go (Remote)
+
+The recommended package for **any application that connects to a remote Turso Cloud database** over the network — web servers, Docker containers, serverless functions. Pure Go, no native dependencies.
+
+### Installing
+
+```bash
+go get github.com/tursodatabase/libsql-client-go/libsql
+```
+
+### Connecting
+
+```go
+import (
+	"database/sql"
+	"os"
+	_ "github.com/tursodatabase/libsql-client-go/libsql"
+)
+
+url := os.Getenv("TURSO_DATABASE_URL") + "?authToken=" + os.Getenv("TURSO_AUTH_TOKEN")
+db, err := sql.Open("libsql", url)
+```
+
+### Querying
+
+Uses the standard `database/sql` interface — same as `tursogo`:
+
+```go
+rows, err := db.Query("SELECT * FROM users WHERE id = ?", 1)
+```
+
+## go-libsql (Legacy)
+
+The `go-libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. It is fully supported — if you run into something that doesn't work yet with `tursogo`, `go-libsql` is a reliable fallback.
+
+<Info>
+
+With `go-libsql` embedded replicas, reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use `tursogo` with `NewTursoSyncDb` — see the [quickstart](/sdk/go/quickstart).
+
+</Info>
+
+### Embedded Replicas
+
+<Warning>
+
+For new projects, we recommend `tursogo` with `NewTursoSyncDb` for sync use cases — it is built on the Turso Database engine with better performance, true local-first writes, and concurrent write support.
+
+</Warning>
 
 You can work with [embedded replicas](/features/embedded-replicas) that can sync from the remote database to a local SQLite file, and delegate writes to the remote primary database:
 
@@ -48,9 +239,7 @@ func main() {
 
 <Snippet file="embedded-replicas-warning.mdx" />
 
-### Manual Sync
-
-The `Sync` function allows you to sync manually the local database with the remote counterpart:
+#### Manual Sync
 
 ```go
 if err := connector.Sync(); err != nil {
@@ -58,9 +247,7 @@ if err := connector.Sync(); err != nil {
 }
 ```
 
-### Periodic Sync
-
-You can automatically sync at intervals using `WithSyncInterval` and passing a `time.Duration` as an argument. For example, to sync every minute, you can use the following code:
+#### Periodic Sync
 
 ```go
 syncInterval := time.Minute
@@ -71,7 +258,7 @@ connector, err := libsql.NewEmbeddedReplicaConnector(dbPath, primaryUrl,
 )
 ```
 
-### Read Your Writes
+#### Read Your Writes
 
 By default, the database connection ensures that writes are immediately visible to subsequent read operations initiated by the same connection.
 
@@ -84,7 +271,13 @@ connector, err := libsql.NewEmbeddedReplicaConnector(dbPath, primaryUrl,
 )
 ```
 
-## Encryption
+### Encryption
+
+<Warning>
+
+For new projects, we recommend [`tursogo`](#tursogo) for local encryption — it is built on the Turso Database engine with better performance and concurrent write support.
+
+</Warning>
 
 To enable encryption on a SQLite file, pass the encryption key value as an argument to the constructor:
 

--- a/sdk/go/reference.mdx
+++ b/sdk/go/reference.mdx
@@ -260,9 +260,7 @@ connector, err := libsql.NewEmbeddedReplicaConnector(dbPath, primaryUrl,
 
 #### Read Your Writes
 
-By default, the database connection ensures that writes are immediately visible to subsequent read operations initiated by the same connection.
-
-You can disable this behaviour using `WithReadYourWrites(false)`:
+By default, after a sync the server must fully catch up with your changes before returning — guaranteeing you always read your own writes. This is safer but **much slower**, since the server must process all pending changes. If you can tolerate eventually-consistent reads, disable this for significantly faster syncs:
 
 ```go
 connector, err := libsql.NewEmbeddedReplicaConnector(dbPath, primaryUrl,

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -5,14 +5,14 @@ title: Turso SDKs
 
 ## Which package should I use?
 
-| Use case | TypeScript | Python |
-| --- | --- | --- |
-| **Local database** (embedded, on-device, offline) | `@tursodatabase/database` | `pyturso` |
-| **Local database + cloud sync** (push/pull) | `@tursodatabase/sync` | `pyturso` (with sync) |
-| **Remote access** (servers, Docker, serverless, edge — any over-the-wire) | `@tursodatabase/serverless` | `libsql` |
-| **Legacy (libSQL)** — ORM support (Drizzle, Prisma), battle-tested | `@libsql/client` | `libsql` |
+| Use case | TypeScript | Python | Go |
+| --- | --- | --- | --- |
+| **Local database** (embedded, on-device, offline) | `@tursodatabase/database` | `pyturso` | `tursogo` |
+| **Local database + cloud sync** (push/pull) | `@tursodatabase/sync` | `pyturso` (with sync) | `tursogo` (with sync) |
+| **Remote access** (servers, Docker, serverless, edge — any over-the-wire) | `@tursodatabase/serverless` | `libsql` | `libsql-client-go` |
+| **Legacy (libSQL)** — ORM support (Drizzle, Prisma), battle-tested | `@libsql/client` | `libsql` | `go-libsql` |
 
-**Starting a new project?** Use `@tursodatabase/database` (TypeScript) or `pyturso` (Python). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and true local-first sync.
+**Starting a new project?** Use `@tursodatabase/database` (TypeScript), `pyturso` (Python), or `tursogo` (Go). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and true local-first sync.
 
 **Need sync?** Use [Turso Sync](/sync/usage) for local reads and writes with explicit `push()` / `pull()` to Turso Cloud.
 
@@ -20,7 +20,7 @@ title: Turso SDKs
 
 **Migrating from SQLite?** Turso Database is a drop-in replacement. Your existing SQL, schema, and queries work unchanged.
 
-**Already using `@libsql/client` or `libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. They are fully supported and battle-tested. Consider migrating to the Turso Database packages for better sync support and concurrent writes — but if you run into something that doesn't work yet with the newer packages, `@libsql/client` and `libsql` are reliable fallbacks.
+**Already using `@libsql/client`, `libsql`, or `go-libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. They are fully supported and battle-tested. Consider migrating to the Turso Database packages for better sync support and concurrent writes — but if you run into something that doesn't work yet with the newer packages, `@libsql/client`, `libsql`, and `go-libsql` are reliable fallbacks.
 
 ### Why multiple packages in TypeScript?
 

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -5,14 +5,14 @@ title: Turso SDKs
 
 ## Which package should I use?
 
-| Use case | TypeScript | Python | Go |
-| --- | --- | --- | --- |
-| **Local database** (embedded, on-device, offline) | `@tursodatabase/database` | `pyturso` | `tursogo` |
-| **Local database + cloud sync** (push/pull) | `@tursodatabase/sync` | `pyturso` (with sync) | `tursogo` (with sync) |
-| **Remote access** (servers, Docker, serverless, edge — any over-the-wire) | `@tursodatabase/serverless` | `libsql` | `libsql-client-go` |
-| **Legacy (libSQL)** — ORM support (Drizzle, Prisma), battle-tested | `@libsql/client` | `libsql` | `go-libsql` |
+| Use case | TypeScript | Python | Go | Rust |
+| --- | --- | --- | --- | --- |
+| **Local database** (embedded, on-device, offline) | `@tursodatabase/database` | `pyturso` | `tursogo` | `turso` |
+| **Local database + cloud sync** (push/pull) | `@tursodatabase/sync` | `pyturso` (with sync) | `tursogo` (with sync) | `turso` (with `sync` feature) |
+| **Remote access** (servers, Docker, serverless, edge — any over-the-wire) | `@tursodatabase/serverless` | `libsql` | `libsql-client-go` | `libsql` (with `remote` feature) |
+| **Legacy (libSQL)** — ORM support (Drizzle, Prisma), battle-tested | `@libsql/client` | `libsql` | `go-libsql` | `libsql` |
 
-**Starting a new project?** Use `@tursodatabase/database` (TypeScript), `pyturso` (Python), or `tursogo` (Go). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and true local-first sync.
+**Starting a new project?** Use `@tursodatabase/database` (TypeScript), `pyturso` (Python), `tursogo` (Go), or `turso` (Rust). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and true local-first sync.
 
 **Need sync?** Use [Turso Sync](/sync/usage) for local reads and writes with explicit `push()` / `pull()` to Turso Cloud.
 
@@ -20,7 +20,7 @@ title: Turso SDKs
 
 **Migrating from SQLite?** Turso Database is a drop-in replacement. Your existing SQL, schema, and queries work unchanged.
 
-**Already using `@libsql/client`, `libsql`, or `go-libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. They are fully supported and battle-tested. Consider migrating to the Turso Database packages for better sync support and concurrent writes — but if you run into something that doesn't work yet with the newer packages, `@libsql/client`, `libsql`, and `go-libsql` are reliable fallbacks.
+**Already using `@libsql/client`, `libsql`, or `go-libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. They are fully supported and battle-tested. Consider migrating to the Turso Database packages for better sync support and concurrent writes — but if you run into something that doesn't work yet with the newer packages, the libSQL-based ones are reliable fallbacks.
 
 ### Why multiple packages in TypeScript?
 

--- a/sdk/rust/quickstart.mdx
+++ b/sdk/rust/quickstart.mdx
@@ -1,126 +1,170 @@
 ---
 title: Turso Quickstart (Rust)
 sidebarTitle: Quickstart
-description: Get started with Turso and Rust using the libSQL crate in a few simple steps
+description: Get started with Turso and Rust in a few simple steps.
 ---
 
 In this Rust quickstart we will learn how to:
 
-- Retrieve database credentials
-- Install the Rust libSQL crate
-- Connect to a local or remote Turso database
+- Install the Turso crate
+- Connect to a local or remote database
 - Execute a query using SQL
-- Sync changes to local database
+- Sync changes to the cloud
+
+## Recommended: turso (Local + Cloud Sync)
+
+`turso` is the recommended crate for running a local database, including synchronizing it to and from Turso Cloud. It is built on the Turso Database engine — a ground-up rewrite of SQLite with concurrent writes (MVCC), async I/O, and native Rust async/await support.
 
 <Steps>
-  <Step title="Retrieve database credentials">
-
-    You will need an existing database to continue. If you don't have one, [create one](/quickstart).
-
-    <Snippet file="retrieve-database-credentials.mdx" />
-
-    <Info>You will want to store these as environment variables.</Info>
-
-  </Step>
-
   <Step title="Install">
 
-    First begin by installing the `libsql` [crate](https://crates.io/crates/libsql):
-
-    ```bash
-    cargo add libsql
-    ```
+```bash
+cargo add turso tokio --features tokio/full
+```
 
   </Step>
-
   <Step title="Connect">
 
-You must first create a `Database` object and then open a `Connection` to it:
-
-<AccordionGroup>
-  <Accordion title="Embedded Replicas">
-
 ```rust
-use libsql::Builder;
+use turso::Builder;
 
-let url = std::env::var("TURSO_DATABASE_URL").expect("TURSO_DATABASE_URL must be set");
-let token = std::env::var("TURSO_AUTH_TOKEN").expect("TURSO_AUTH_TOKEN must be set");
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = Builder::new_local("app.db").build().await?;
+    let conn = db.connect()?;
 
-let db = Builder::new_remote_replica("local.db", url, token)
-    .build()
-    .await?;
-let conn = db.connect()?;
-```
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        )",
+        (),
+    ).await?;
 
-  </Accordion>
-  <Accordion title="Local only">
+    conn.execute("INSERT INTO users (name) VALUES (?)", ("Alice",)).await?;
 
-```rust
-use libsql::Builder;
+    let mut rows = conn.query("SELECT * FROM users", ()).await?;
+    while let Some(row) = rows.next().await? {
+        let id: i64 = row.get(0)?;
+        let name: String = row.get(1)?;
+        println!("User: {} {}", id, name);
+    }
 
-let db = Builder::new_local("local.db").build().await?;
-let conn = db.connect()?;
-```
-
-  </Accordion>
-  <Accordion title="Remote only">
-
-```rust
-use libsql::Builder;
-
-let url = std::env::var("TURSO_DATABASE_URL").expect("TURSO_DATABASE_URL must be set");
-let token = std::env::var("TURSO_AUTH_TOKEN").expect("TURSO_AUTH_TOKEN must be set");
-
-let db = Builder::new_remote(url, token)
-    .build()
-    .await?;
-let conn = db.connect()?;
-```
-
-  </Accordion>
-</AccordionGroup>
-
-  </Step>
-
-  <Step title="Execute">
-
-You can execute a SQL query against your existing database by calling `execute()`:
-
-```rust
-conn.execute("SELECT * FROM users", ()).await?;
-```
-
-If you need to use placeholders for values, you can do that:
-
-<CodeGroup>
-
-```rust Positional
-conn.execute("SELECT * FROM users WHERE id = ?1", libsql::params![1]).await?;
-```
-
-```rust Named
-conn.execute("INSERT INTO users (name) VALUES (:name)", libsql::named_params! { ":name": "Iku" }).await?;
-```
-
-</CodeGroup>
-
-To retrieve results from a query, you can use the `query()` method:
-
-```rust
-let mut rows = conn.query("SELECT * FROM users", ()).await?;
-
-while let Some(row) = rows.next().await? {
-    let id: i64 = row.get(0)?;
-    let name: String = row.get(1)?;
-    println!("User: {} - {}", id, name);
+    Ok(())
 }
 ```
 
   </Step>
+  <Step title="Sync (push and pull)">
 
-  <Step title="Sync">
+If you need to sync your local database with Turso Cloud, enable the `sync` feature:
 
-If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides true local-first sync with explicit `push()` and `pull()` operations.
+```bash
+cargo add turso --features sync
+```
+
+```rust
+use turso::sync::Builder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = Builder::new_remote("app.db")
+        .with_remote_url(&std::env::var("TURSO_DATABASE_URL")?)
+        .with_auth_token(&std::env::var("TURSO_AUTH_TOKEN")?)
+        .build()
+        .await?;
+
+    let conn = db.connect().await?;
+
+    conn.execute("INSERT INTO users (name) VALUES (?)", ("Bob",)).await?;
+
+    // Push local writes to Turso Cloud
+    db.push().await?;
+
+    // Pull remote changes to local database
+    db.pull().await?;
+
+    Ok(())
+}
+```
+
+All reads and writes happen against the local database file — fast, offline-capable. `push()` sends your changes to the cloud. `pull()` brings remote changes down. See the [reference](/sdk/rust/reference) for checkpoint, stats, and encryption. See [Turso Sync](/sync/usage) for details on conflict resolution and more.
+
+<Info>
+
+You can test sync locally without a Turso Cloud account by starting a local sync server:
+
+```bash
+tursodb :memory: --sync-server 127.0.0.1:8080
+```
+
+Then use `http://127.0.0.1:8080` as the remote URL (no auth token needed). See [Turso Database quickstart](/tursodb/quickstart) for how to install `tursodb`.
+
+</Info>
 
   </Step>
 </Steps>
+
+## Remote Access (Over-the-Wire)
+
+If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), use the `libsql` crate with the `remote` feature. It connects over HTTP — no local file needed, no C compiler required.
+
+<Info>
+
+For most applications, we recommend running a local database with sync (`turso::sync`) instead — it gives you faster reads, offline support, and lower latency. Remote access is useful when you cannot store a local database file (e.g., stateless serverless environments).
+
+</Info>
+
+<Steps>
+  <Step title="Retrieve database credentials">
+
+You will need an existing database to continue. If you don't have one, [create one](/quickstart).
+
+<Snippet file="retrieve-database-credentials.mdx" />
+
+<Info>You will want to store these as environment variables.</Info>
+
+  </Step>
+  <Step title="Install">
+
+```bash
+cargo add libsql --features remote
+```
+
+  </Step>
+  <Step title="Connect and query">
+
+```rust
+use libsql::Builder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = std::env::var("TURSO_DATABASE_URL")?;
+    let token = std::env::var("TURSO_AUTH_TOKEN")?;
+
+    let db = Builder::new_remote(url, token).build().await?;
+    let conn = db.connect()?;
+
+    let mut rows = conn.query("SELECT * FROM users", ()).await?;
+    while let Some(row) = rows.next().await? {
+        let id: i64 = row.get(0)?;
+        let name: String = row.get(1)?;
+        println!("User: {} {}", id, name);
+    }
+
+    Ok(())
+}
+```
+
+  </Step>
+</Steps>
+
+## Legacy: libsql (Embedded Replicas)
+
+<Warning>
+
+**Usage of embedded replicas is strongly discouraged.** With embedded replicas, reads are local but **writes are sent to the remote database** — this means writes fail when offline, have higher latency, and don't support concurrent writes. Use the `turso` crate with `turso::sync` instead: all reads and writes are local, and you explicitly sync with `push()` / `pull()`.
+
+</Warning>
+
+See the [reference](/sdk/rust/reference) for legacy documentation on embedded replicas if you have an existing `libsql` codebase.

--- a/sdk/rust/reference.mdx
+++ b/sdk/rust/reference.mdx
@@ -1,157 +1,262 @@
 ---
 title: Reference
-description: libSQL Rust Reference
+description: Rust Reference for Turso
 ---
 
-The libSQL Rust crate contains everything you need to work with Turso and works flawlessly with popular async runtimes like `tokio`.
+Turso offers two Rust crates:
 
-## Installing
+| | `turso` | `libsql` (legacy) |
+| --- | --- | --- |
+| **Use case** | Local / embedded database, sync | Remote access, legacy embedded replicas |
+| **Engine** | Turso Database (rewrite) | libSQL (SQLite fork) |
+| **Concurrent writes** | Yes (MVCC) | Not supported |
+| **Sync** | push/pull (true local-first) | Embedded replicas (writes go to remote) |
+| **C compiler** | Not required | Required for `core`, `replication`, `encryption` features |
 
-Install the crate in your project using the following command:
+**Starting a new project?** Use `turso` for local/embedded use or sync. Use `libsql` with the `remote` feature for over-the-wire access (no C compiler needed).
+
+## turso
+
+For local and embedded use. Built on the Turso Database engine with concurrent writes (MVCC) and async I/O.
+
+### Installing
 
 ```bash
-cargo add libsql
+cargo add turso tokio --features tokio/full
 ```
 
-### Conditional compilation
-
-The libsql rust client supports [conditionally compiling](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) certain features to reduce compile times depending on what features you would like to use.
-
-The following features are available:
-
-| Feature       | Description                                                                                                                                                                                                                                          |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `remote`      | Enables the HTTP-only client, allowing communication with a remote sqld server using pure Rust. Does not require compiling C code for SQLite. Suitable for projects that only need to interact with a remote database.                               |
-| `core`        | Enables the local database only, incorporating the C SQLite3 code into the build. This is the foundation for local database operations but does not include additional features like replication or encryption.                                      |
-| `replication` | Combines core with additional code required for replication, enabling the embedded replica features.                                                                                                                                                 |
-| `encryption`  | Enables encryption at rest support, adding the necessary code to compile encryption capabilities and expose functions for configuring it. **This is optional and not enabled by default**, catering to projects that require enhanced data security. |
-
-```toml
-[dependencies]
-libsql = { version = "...", features = ["encryption"] }
-```
-
-<Note>
-
-Using `core` and `replication` features require a c compiler. The `encryption` feature requires `cmake` to be installed on your system.
-
-</Note>
-
-## Initializing
-
-Make sure add the crate to your project at the top of your file:
+### Connecting
 
 ```rust
-use libsql::Builder;
+use turso::Builder;
 
-let url = env::var("LIBSQL_URL").expect("LIBSQL_URL must be set");
-let token = env::var("LIBSQL_AUTH_TOKEN").unwrap_or_default();
-
-let mut db = Builder::new_remote_replica("local.db", &url, &token).build().await.unwrap();
-let conn = db.connect().unwrap();
+let db = Builder::new_local("app.db").build().await?;
+let conn = db.connect()?;
 ```
 
-## In-Memory Databases
-
-libSQL supports connecting to [in-memory databases](https://www.sqlite.org/inmemorydb.html) for cases where you don't require persistence:
+In-memory databases are also supported:
 
 ```rust
-use libsql::Builder;
-
-let db = Builder::new_local(":memory:").build().await.unwrap();
-let conn = db.connect().unwrap();
+let db = Builder::new_local(":memory:").build().await?;
 ```
 
-## Local Development
-
-You can work locally using an SQLite file using `new_local`:
+### Querying
 
 ```rust
-use libsql::Builder;
+conn.execute(
+    "CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL
+    )",
+    (),
+).await?;
 
-let mut db = Builder::new_local("local.db").build().await.unwrap();
-let conn = db.connect().unwrap();
+conn.execute("INSERT INTO users (name) VALUES (?)", ("Alice",)).await?;
+
+let mut rows = conn.query("SELECT * FROM users", ()).await?;
+while let Some(row) = rows.next().await? {
+    let id: i64 = row.get(0)?;
+    let name: String = row.get(1)?;
+    println!("User: {} {}", id, name);
+}
 ```
 
-## Embedded Replicas
-
-You can work with embedded replicas using `new_remote_replica` that can sync from the remote URL and delegate writes to the remote primary database:
+### Prepared Statements
 
 ```rust
-use libsql::Builder;
-
-let url = env::var("LIBSQL_URL").expect("LIBSQL_URL must be set");
-let token = env::var("LIBSQL_AUTH_TOKEN").unwrap_or_default();
-
-let mut db = Builder::new_remote_replica("local.db", &url, &token).build().await.unwrap();
-let conn = db.connect().unwrap();
+let mut stmt = conn.prepare("SELECT * FROM users WHERE id = ?1").await?;
+let mut rows = stmt.query([42]).await?;
 ```
 
-### Manual Sync
-
-The `sync` function allows you to sync manually the local database with the remote counterpart:
+### Transactions
 
 ```rust
-use libsql::Builder;
+let tx = conn.transaction().await?;
 
-let url = env::var("LIBSQL_URL").expect("LIBSQL_URL must be set");
-let token = env::var("LIBSQL_AUTH_TOKEN").unwrap_or_default();
+tx.execute("INSERT INTO users (name) VALUES (?1)", ["Alice"]).await?;
+tx.execute("INSERT INTO users (name) VALUES (?1)", ["Bob"]).await?;
 
-let mut db = Builder::new_remote_replica("local.db", &url, &token).build().await.unwrap();
-
-let conn = db.connect().unwrap();
-
-db.sync().await.unwrap(); // Call sync manually to update local database
+tx.commit().await?;
 ```
+
+### Encryption
+
+Encrypt local databases at rest:
+
+```rust
+use turso::{Builder, EncryptionOpts};
+
+let db = Builder::new_local("encrypted.db")
+    .experimental_encryption(true)
+    .with_encryption(EncryptionOpts {
+        cipher: "aegis256".to_string(),
+        hexkey: "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327".to_string(),
+    })
+    .build()
+    .await?;
+```
+
+Supported ciphers: `aegis256`, `aegis256x2`, `aegis128l`, `aegis128x2`, `aegis128x4`, `aes256gcm`, `aes128gcm`.
+
+Encrypted databases cannot be read as standard SQLite databases — you must use the Turso Database engine to open them.
 
 <Info>
 
-If you require full control over how frames get from your instance of `sqld` (libSQL Server), you can do this using `new_local_replica` and `sync_frames`. Reach out to us [on Discord](https://tur.so/discord) if you want to learn more.
+Turso Cloud databases can also be encrypted with bring-your-own-key — [learn more](/cloud/encryption).
 
 </Info>
 
-### Sync Interval
+### Sync (Push and Pull)
 
-The `sync_interval` function allows you to set an interval for automatic synchronization of the database in the background:
+For local database with cloud sync. All reads and writes happen locally; use `push()` to send changes to the cloud and `pull()` to fetch remote changes.
+
+Enable the `sync` feature:
+
+```bash
+cargo add turso --features sync
+```
+
+```rust
+use turso::sync::Builder;
+
+let db = Builder::new_remote("app.db")
+    .with_remote_url(&std::env::var("TURSO_DATABASE_URL")?)
+    .with_auth_token(&std::env::var("TURSO_AUTH_TOKEN")?)
+    .bootstrap_if_empty(true)  // Download schema on first sync (default)
+    .build()
+    .await?;
+
+let conn = db.connect().await?;
+```
+
+On the first run, the local database is automatically bootstrapped from the remote. See [Turso Sync](/sync/usage) for full details.
+
+#### Push and Pull
+
+```rust
+// Push local writes to Turso Cloud
+db.push().await?;
+
+// Pull remote changes (returns true if changes were applied)
+let changed = db.pull().await?;
+```
+
+#### Checkpoint
+
+Compact the local WAL to bound disk usage while preserving sync state:
+
+```rust
+db.checkpoint().await?;
+```
+
+#### Stats
+
+```rust
+let stats = db.stats().await?;
+println!("Network received: {} bytes", stats.network_received_bytes);
+println!("Network sent: {} bytes", stats.network_sent_bytes);
+println!("WAL size: {} bytes", stats.main_wal_size);
+```
+
+## libsql (Remote)
+
+Use the `libsql` crate with the `remote` feature for over-the-wire access to Turso Cloud. This uses pure Rust HTTP — no C compiler needed.
+
+### Installing
+
+```bash
+cargo add libsql --features remote
+```
+
+### Connecting
 
 ```rust
 use libsql::Builder;
+
+let url = std::env::var("TURSO_DATABASE_URL")?;
+let token = std::env::var("TURSO_AUTH_TOKEN")?;
+
+let db = Builder::new_remote(url, token).build().await?;
+let conn = db.connect()?;
+```
+
+### Querying
+
+```rust
+let mut rows = conn.query("SELECT * FROM users WHERE id = ?1", [1]).await?;
+```
+
+## libsql (Legacy)
+
+The `libsql` crate is built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. It is fully supported — if you run into something that doesn't work yet with the `turso` crate, `libsql` is a reliable fallback.
+
+<Info>
+
+With `libsql` embedded replicas, reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use the `turso` crate with `turso::sync` — see the [quickstart](/sdk/rust/quickstart).
+
+</Info>
+
+### Embedded Replicas
+
+<Warning>
+
+**Usage of embedded replicas is strongly discouraged.** Use the `turso` crate with `turso::sync` instead — it is built on the Turso Database engine with better performance, true local-first writes, and concurrent write support.
+
+</Warning>
+
+You can work with [embedded replicas](/features/embedded-replicas) that can sync from the remote database to a local SQLite file, and delegate writes to the remote primary database:
+
+```rust
+use libsql::Builder;
+
+let url = std::env::var("TURSO_DATABASE_URL")?;
+let token = std::env::var("TURSO_AUTH_TOKEN")?;
+
+let db = Builder::new_remote_replica("local.db", url, token)
+    .build()
+    .await?;
+let conn = db.connect()?;
+```
+
+<Snippet file="embedded-replicas-warning.mdx" />
+
+#### Manual Sync
+
+```rust
+db.sync().await?;
+```
+
+#### Sync Interval
+
+```rust
 use std::time::Duration;
 
-let url = env::var("LIBSQL_URL").expect("LIBSQL_URL must be set");
-let token = env::var("LIBSQL_AUTH_TOKEN").unwrap_or_default();
-
-let mut db = Builder::new_remote_replica("local.db", &url, &token)
-  .sync_interval(Duration::from_secs(300)) // Sync every 5 minutes
-  .build()
-  .await.unwrap();
-
-let conn = db.connect().unwrap();
+let db = Builder::new_remote_replica("local.db", url, token)
+    .sync_interval(Duration::from_secs(300))
+    .build()
+    .await?;
 ```
 
-### Read Your Own Writes
+#### Read Your Own Writes
 
-The `read_your_writes` function configures the database connection to ensure that writes are immediately visible to subsequent read operations initiated by the same connection. This is **enabled by default**, and is particularly important in distributed systems to ensure consistency from the perspective of the writing process.
-
-You can disable this behavior by passing `false` to the function:
+By default, after a `push()`, the next `pull()` waits for the server to fully catch up with your changes before returning — guaranteeing you always read your own writes. This is safer but **much slower**, since the server must process all pending changes. If you can tolerate eventually-consistent reads, disable this for significantly faster pulls:
 
 ```rust
-use libsql::Builder;
-
-let url = env::var("LIBSQL_URL").expect("LIBSQL_URL must be set");
-let token = env::var("LIBSQL_AUTH_TOKEN").unwrap_or_default();
-
-let mut db = Builder::new_remote_replica("local.db", &url, &token)
-  .read_your_writes(false) // Disable reading your own writes
-  .build()
-  .await.unwrap();
-
-let conn = db.connect().unwrap();
+let db = Builder::new_remote_replica("local.db", url, token)
+    .read_your_writes(false)
+    .build()
+    .await?;
 ```
 
-## Encryption
+### Encryption
 
-To enable encryption on a SQLite file (`new_local` or `new_remote_replica`), make sure you have the [`encryption` feature enabled](#conditional-compilation), and pass the `encryption_config`:
+<Warning>
+
+For new projects, we recommend the [`turso`](#turso) crate for local encryption — it is built on the Turso Database engine with better performance and concurrent write support.
+
+</Warning>
+
+To enable encryption on a SQLite file, pass the encryption key value as an argument to the constructor:
 
 <Snippet file="encryption-at-rest-rust.mdx" />
 
@@ -161,46 +266,30 @@ Encrypted databases appear as raw data and cannot be read as standard SQLite dat
 
 </Info>
 
-## Simple query
+### Conditional compilation
 
-You can pass a string to `execute()` to invoke a SQL statement, as well as optional arguments:
+The `libsql` crate supports [conditionally compiling](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) features:
 
-<CodeGroup>
+| Feature       | Description                                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `remote`      | HTTP-only client, pure Rust. No C compiler needed.                                                                |
+| `core`        | Local database only. Requires a C compiler.                                                                       |
+| `replication` | Combines `core` with embedded replica support. Requires a C compiler.                                             |
+| `encryption`  | Encryption at rest. Requires `cmake`. Not enabled by default.                                                     |
 
-```rust Query
+### Simple query
+
+```rust
 conn.execute("SELECT * FROM users", ()).await?;
-```
-
-```rust Arguments
 conn.execute("SELECT * FROM users WHERE id = ?1", [1]).await?;
 ```
 
-</CodeGroup>
-
-## Prepared Statements
-
-You can prepare a cached statement using `prepare()` and then execute it with `query()`:
-
-```rust
-let mut stmt = db_conn.prepare("SELECT * FROM users").await?;
-
-db_conn.query(&stmt, [&1]).await?;
-
-// reset state when calling with different parameters
-stmt.reset();
-
-db_conn.query(&stmt, [&2]).await?;
-
-```
-
-## Placeholders
-
-libSQL supports the use of positional and named placeholders within SQL statements:
+### Placeholders
 
 <CodeGroup>
 
 ```rust Positional
-conn.execute("SELECT * FROM users WHERE id = ?1", params![1]).await?;
+conn.execute("SELECT * FROM users WHERE id = ?1", libsql::params![1]).await?;
 ```
 
 ```rust Named
@@ -209,40 +298,23 @@ conn.execute("INSERT INTO users (name) VALUES (:name)", libsql::named_params! { 
 
 </CodeGroup>
 
-## Deserialization
-
-You can use the `de::from_row` function to deserialize a row into a struct:
+### Deserialization
 
 ```rust
 use libsql::{de, Builder};
 
-let mut stmt = conn
-  .prepare("SELECT * FROM users WHERE id = ?1")
-  .await
-  .unwrap();
-let row = stmt
-  .query([1])
-  .await
-  .unwrap()
-  .next()
-  .await
-  .unwrap()
-  .unwrap();
-
 #[derive(Debug, serde::Deserialize)]
 struct User {
-  name: String,
-  age: i64,
-  vision: f64,
-  avatar: Vec<u8>,
+    name: String,
+    age: i64,
 }
 
-let user = de::from_row::<User>(&row).unwrap();
+let mut stmt = conn.prepare("SELECT * FROM users WHERE id = ?1").await?;
+let row = stmt.query([1]).await?.next().await?.unwrap();
+let user = de::from_row::<User>(&row)?;
 ```
 
-## Batch Transactions
-
-A batch consists of multiple SQL statements executed sequentially within an implicit transaction. The backend handles the transaction: success commits all changes, while any failure results in a full rollback with no modifications.
+### Batch Transactions
 
 ```rust
 conn.execute_batch(r#"
@@ -256,35 +328,27 @@ conn.execute_batch(r#"
 "#).await?;
 ```
 
-## Interactive Transactions
-
-Interactive transactions in SQLite ensure the consistency of a series of read and write operations within a transaction's scope. These transactions give you control over when to commit or roll back changes, isolating them from other client activity.
-
-- `transaction()` &mdash; with default transaction behavior (`DEFFERED`)
-- `transaction_with_behavior()` &mdash; with custom transaction behavior
+### Interactive Transactions
 
 <CodeGroup>
 
 ```rust Default
-let mut tx = db_conn.transaction().await?;
+let tx = conn.transaction().await?;
 
-tx.execute("INSERT INTO users (name) VALUES (?1)", ["Iku"]).await?;
-tx.execute("INSERT INTO users (name) VALUES (?1)", ["Iku 2"]).await?;
+tx.execute("INSERT INTO users (name) VALUES (?1)", ["Alice"]).await?;
+tx.execute("INSERT INTO users (name) VALUES (?1)", ["Bob"]).await?;
 
 tx.commit().await?;
 ```
 
 ```rust Advanced control
-let mut tx = db_conn.transaction_with_behavior(TransactionBehavior::Immediate).await?;
+use libsql::TransactionBehavior;
+
+let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate).await?;
 
 tx.execute("UPDATE users SET age = age + 1 WHERE id = ?1", [1]).await?;
-tx.execute("DELETE FROM users WHERE id = ?1", [2]).await?;
 
-if operations_successful {
-  tx.commit().await?;
-} else {
-  tx.rollback().await?;
-}
+tx.commit().await?;
 ```
 
 </CodeGroup>


### PR DESCRIPTION
We have already reworked the docs for typescript and python.

Although go and rust are trailing behind those two, they are still fully supported drivers so I am bringing them up to speed as well.