### PR TITLE
Sync SQL reference: add CLI docs, new statements & functions

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -87,6 +87,14 @@
             ]
           },
           {
+            "group": "CLI Reference",
+            "pages": [
+              "sql-reference/cli/getting-started",
+              "sql-reference/cli/command-line-options",
+              "sql-reference/cli/shell-commands"
+            ]
+          },
+          {
             "group": "SQL Reference",
             "pages": [
               "sql-reference/compatibility",
@@ -102,12 +110,14 @@
                   "sql-reference/statements/create-materialized-view",
                   "sql-reference/statements/create-trigger",
                   "sql-reference/statements/create-type",
+                  "sql-reference/statements/create-domain",
                   "sql-reference/statements/create-virtual-table",
                   "sql-reference/statements/drop-table",
                   "sql-reference/statements/drop-index",
                   "sql-reference/statements/drop-view",
                   "sql-reference/statements/drop-trigger",
                   "sql-reference/statements/drop-type",
+                  "sql-reference/statements/drop-domain",
                   "sql-reference/statements/select",
                   "sql-reference/statements/insert",
                   "sql-reference/statements/update",
@@ -118,7 +128,8 @@
                   "sql-reference/statements/transactions",
                   "sql-reference/statements/attach-database",
                   "sql-reference/statements/detach-database",
-                  "sql-reference/statements/analyze"
+                  "sql-reference/statements/analyze",
+                  "sql-reference/statements/vacuum"
                 ]
               },
               {
@@ -131,9 +142,11 @@
                   "sql-reference/functions/date-time",
                   "sql-reference/functions/json",
                   "sql-reference/functions/vector",
+                  "sql-reference/functions/array",
                   "sql-reference/functions/fts"
                 ]
               },
+              "sql-reference/multiprocess-access",
               "sql-reference/extensions",
               "sql-reference/pragmas",
               "sql-reference/experimental-features"

--- a/scripts/sync-sql-reference.py
+++ b/scripts/sync-sql-reference.py
@@ -136,12 +136,14 @@ STATEMENTS_ORDER = [
     "create-materialized-view",
     "create-trigger",
     "create-type",
+    "create-domain",
     "create-virtual-table",
     "drop-table",
     "drop-index",
     "drop-view",
     "drop-trigger",
     "drop-type",
+    "drop-domain",
     "select",
     "insert",
     "update",
@@ -153,6 +155,7 @@ STATEMENTS_ORDER = [
     "attach-database",
     "detach-database",
     "analyze",
+    "vacuum",
 ]
 
 FUNCTIONS_ORDER = [
@@ -163,15 +166,24 @@ FUNCTIONS_ORDER = [
     "date-time",
     "json",
     "vector",
+    "array",
     "fts",
 ]
 
 BOTTOM_LEVEL_ORDER = [
+    "multiprocess-access",
     "extensions",
     "pragmas",
     "experimental-features",
 ]
 
+CLI_ORDER = [
+    "getting-started",
+    "command-line-options",
+    "shell-commands",
+]
+
+CLI_REFERENCE_GROUP_NAME = "CLI Reference"
 SQL_REFERENCE_GROUP_NAME = "SQL Reference"
 TURSO_DB_TAB_NAME = "Turso Database (beta)"
 
@@ -220,11 +232,15 @@ def sort_pages(pages: list[str], preferred_order: list[str]) -> list[str]:
     return known + unknown
 
 
-def build_navigation(copied_files: list[str]) -> dict:
-    """Build the SQL Reference navigation group from copied file paths."""
+def build_navigation(copied_files: list[str]) -> tuple[dict | None, dict]:
+    """Build navigation groups from copied file paths.
+
+    Returns (cli_group, sql_group) where cli_group may be None if no CLI files.
+    """
     top_level = []
     statements = []
     functions = []
+    cli = []
 
     for page in copied_files:
         parts = page.split(os.sep)
@@ -234,6 +250,8 @@ def build_navigation(copied_files: list[str]) -> dict:
             statements.append(parts[1])
         elif parts[0] == "functions":
             functions.append(parts[1])
+        elif parts[0] == "cli":
+            cli.append(parts[1])
 
     # Separate into top pages (before subgroups) and bottom pages (after)
     top_pages = sort_pages(
@@ -250,11 +268,22 @@ def build_navigation(copied_files: list[str]) -> dict:
 
     statements = sort_pages(statements, STATEMENTS_ORDER)
     functions = sort_pages(functions, FUNCTIONS_ORDER)
+    cli = sort_pages(cli, CLI_ORDER)
 
     prefix = "sql-reference"
+
+    # CLI Reference group (separate from SQL Reference)
+    cli_group = None
+    if cli:
+        cli_group = {
+            "group": CLI_REFERENCE_GROUP_NAME,
+            "pages": [f"{prefix}/cli/{c}" for c in cli],
+        }
+
+    # SQL Reference group
     pages = []
 
-    # Top-level pages first
+    # Top-level pages
     for p in top_pages:
         pages.append(f"{prefix}/{p}")
 
@@ -276,11 +305,31 @@ def build_navigation(copied_files: list[str]) -> dict:
     for p in bottom_pages:
         pages.append(f"{prefix}/{p}")
 
-    return {"group": SQL_REFERENCE_GROUP_NAME, "pages": pages}
+    sql_group = {"group": SQL_REFERENCE_GROUP_NAME, "pages": pages}
+
+    return cli_group, sql_group
 
 
-def update_docs_json(nav_group: dict) -> None:
-    """Insert or replace the SQL Reference group in docs.json."""
+def _upsert_group(groups: list[dict], nav_group: dict, insert_before: str | None = None) -> None:
+    """Replace an existing group by name, or insert it (before insert_before if given)."""
+    name = nav_group["group"]
+    for i, group in enumerate(groups):
+        if group.get("group") == name:
+            groups[i] = nav_group
+            return
+
+    # Not found — insert before the named group, or append
+    if insert_before:
+        for i, group in enumerate(groups):
+            if group.get("group") == insert_before:
+                groups.insert(i, nav_group)
+                return
+
+    groups.append(nav_group)
+
+
+def update_docs_json(cli_group: dict | None, sql_group: dict) -> None:
+    """Insert or replace the CLI Reference and SQL Reference groups in docs.json."""
     with open(DOCS_JSON, "r") as f:
         docs = json.load(f)
 
@@ -298,16 +347,12 @@ def update_docs_json(nav_group: dict) -> None:
 
     groups = turso_tab.get("groups", [])
 
-    # Replace existing SQL Reference group, or append it
-    replaced = False
-    for i, group in enumerate(groups):
-        if group.get("group") == SQL_REFERENCE_GROUP_NAME:
-            groups[i] = nav_group
-            replaced = True
-            break
+    # SQL Reference first (so CLI can insert before it)
+    _upsert_group(groups, sql_group)
 
-    if not replaced:
-        groups.append(nav_group)
+    # CLI Reference right before SQL Reference
+    if cli_group:
+        _upsert_group(groups, cli_group, insert_before=SQL_REFERENCE_GROUP_NAME)
 
     turso_tab["groups"] = groups
 
@@ -328,15 +373,17 @@ def main():
     print(f"  Copied {len(copied)} files")
 
     print("Building navigation...")
-    nav_group = build_navigation(copied)
+    cli_group, sql_group = build_navigation(copied)
     page_count = sum(
         len(entry["pages"]) if isinstance(entry, dict) else 1
-        for entry in nav_group["pages"]
+        for entry in sql_group["pages"]
     )
+    if cli_group:
+        page_count += len(cli_group["pages"])
     print(f"  {page_count} navigation entries")
 
     print(f"Updating {DOCS_JSON}...")
-    update_docs_json(nav_group)
+    update_docs_json(cli_group, sql_group)
     print("Done.")
 
 

--- a/sql-reference/cli/command-line-options.mdx
+++ b/sql-reference/cli/command-line-options.mdx
@@ -1,0 +1,164 @@
+---
+title: Command-Line Options
+description: CLI flags, arguments, and server modes for the tursodb command
+sidebarTitle: Command-Line Options
+---
+
+# Command-Line Options
+
+```bash
+tursodb [OPTIONS] [DATABASE] [SQL]
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `DATABASE` | `:memory:` | Path to a SQLite database file. If omitted, an in-memory database is created |
+| `SQL` | — | SQL statement to execute. If provided, the shell runs the query and exits |
+
+### Examples
+
+```bash
+# In-memory database
+tursodb
+
+# Open an existing file
+tursodb customers.db
+
+# Run a query and exit
+tursodb customers.db "SELECT count(*) FROM orders;"
+
+# Pipe SQL from stdin
+echo "SELECT 1 + 1;" | tursodb -q
+```
+
+## Options
+
+### `-m, --output-mode <MODE>`
+
+Set the output display format.
+
+| Mode | Description |
+|------|-------------|
+| `pretty` | Table with borders (default) |
+| `list` | Pipe-delimited values |
+| `line` | One column per line with column names |
+
+```bash
+tursodb -m list mydata.db "SELECT * FROM users;"
+```
+
+### `-o, --output <PATH>`
+
+Redirect query output to a file instead of stdout.
+
+```bash
+tursodb -o results.txt mydata.db "SELECT * FROM users;"
+```
+
+### `-q, --quiet`
+
+Suppress the startup banner and version information.
+
+```bash
+tursodb -q mydata.db
+```
+
+### `-e, --echo`
+
+Print each SQL statement before executing it. Useful for debugging scripts.
+
+```bash
+echo "SELECT 42;" | tursodb -q -e
+```
+
+```
+SELECT 42;
+42
+```
+
+### `-v, --vfs <VFS>`
+
+Select the Virtual File System backend.
+
+| VFS | Description |
+|-----|-------------|
+| `syscall` | Standard OS file I/O (default) |
+| `memory` | In-memory storage |
+| `io_uring` | Linux io_uring (requires feature flag) |
+
+```bash
+tursodb -v memory
+```
+
+### `-t, --tracing-output <PATH>`
+
+Write internal log traces to a file. Useful for debugging and performance analysis.
+
+```bash
+tursodb -t trace.log mydata.db
+```
+
+### `--readonly`
+
+Open the database in read-only mode. Write operations will return an error.
+
+```bash
+tursodb --readonly production.db "SELECT count(*) FROM users;"
+```
+
+Attempting to write in read-only mode:
+
+```bash
+tursodb --readonly production.db "INSERT INTO users VALUES (1, 'test');"
+# Error: Resource is read-only
+```
+
+### `--mcp`
+
+Start a Model Context Protocol server instead of the interactive shell. This allows AI assistants and other MCP clients to interact with the database via JSON-RPC.
+
+```bash
+tursodb --mcp mydata.db
+```
+
+### `--sync-server <ADDRESS>`
+
+Start a sync server for database replication, listening at the given address.
+
+```bash
+tursodb --sync-server 0.0.0.0:8080 mydata.db
+```
+
+## Experimental Feature Flags
+
+These flags enable features that are still under development. They may change or be removed in future releases.
+
+<Warning>
+Experimental features may have incomplete implementations or known limitations. Use them for testing and development only.
+</Warning>
+
+| Flag | Description |
+|------|-------------|
+| `--experimental-views` | Enable views (`CREATE VIEW` / `DROP VIEW`) |
+| `--experimental-custom-types` | Enable custom types (`CREATE TYPE` / `DROP TYPE`) |
+| `--experimental-encryption` | Enable at-rest database encryption |
+| `--experimental-index-method` | Enable custom index methods. Necessary for FTS and Sparse Vector indexes |
+| `--experimental-autovacuum` | Enable automatic database vacuuming |
+| `--experimental-vacuum` | Enable in-place `VACUUM` |
+| `--experimental-triggers` | Enable triggers (`CREATE TRIGGER` / `DROP TRIGGER`) |
+| `--experimental-attach` | Enable `ATTACH DATABASE` / `DETACH DATABASE` |
+
+```bash
+# Enable views, triggers, and in-place VACUUM
+tursodb --experimental-views --experimental-triggers --experimental-vacuum mydata.db
+```
+
+## Other Flags
+
+| Flag | Description |
+|------|-------------|
+| `--unsafe-testing` | Enable unsafe testing features (e.g., `sqlite_dbpage` writes) |
+| `-h, --help` | Print usage help |
+| `-V, --version` | Print version information |

--- a/sql-reference/cli/getting-started.mdx
+++ b/sql-reference/cli/getting-started.mdx
@@ -1,0 +1,144 @@
+---
+title: Getting Started
+description: Install and use the Turso interactive SQL shell
+sidebarTitle: Getting Started
+---
+
+# Getting Started
+
+The Turso CLI (`tursodb`) is an interactive SQL shell for working with Turso databases. It supports in-memory and file-based databases, multiple output modes, CSV import, database cloning, and built-in documentation.
+
+## Quick Start
+
+### In-Memory Database
+
+Launch the shell with a transient in-memory database:
+
+```bash
+tursodb
+```
+
+### Open a Database File
+
+```bash
+tursodb mydata.db
+```
+
+### Run a Query Directly
+
+Pass SQL as a command-line argument to run it and exit:
+
+```bash
+tursodb mydata.db "SELECT * FROM users;"
+```
+
+### Pipe SQL from stdin
+
+```bash
+echo "SELECT sqlite_version();" | tursodb -q
+```
+
+## Interactive Shell
+
+When launched without a SQL argument, the shell provides an interactive REPL with command history and syntax highlighting.
+
+### Multi-line Input
+
+Unfinished statements (missing semicolons, unbalanced parentheses) automatically continue on the next line. The prompt indicates nesting depth:
+
+```
+tursodb> SELECT *
+   ...>   FROM employees
+   ...>   WHERE department = 'Engineering';
+```
+
+### Command History
+
+Command history is saved automatically to `~/.limbo_history` and accessible with up/down arrow keys.
+
+### Exiting
+
+Use `.quit` or `.exit` to leave the shell. Pressing Ctrl+C twice also exits.
+
+## Output Modes
+
+Turso supports three output modes, selectable with the `-m` flag or the `.mode` dot command.
+
+### Pretty (Default)
+
+Human-readable table with borders:
+
+```bash
+tursodb -q -m pretty
+```
+
+```
+┌────┬─────────┬─────────────┬─────────┐
+│ id │ name    │ department  │ salary  │
+├────┼─────────┼─────────────┼─────────┤
+│  1 │ Alice   │ Engineering │ 95000.0 │
+├────┼─────────┼─────────────┼─────────┤
+│  2 │ Bob     │ Marketing   │ 72000.0 │
+└────┴─────────┴─────────────┴─────────┘
+```
+
+### List
+
+Pipe-delimited values suitable for scripting:
+
+```bash
+tursodb -q -m list
+```
+
+```
+1|Alice|Engineering|95000.0
+2|Bob|Marketing|72000.0
+```
+
+### Line
+
+One column per line, with column names:
+
+```bash
+tursodb -q -m line
+```
+
+```
+        id = 1
+      name = Alice
+department = Engineering
+    salary = 95000.0
+```
+
+## Non-Interactive Mode
+
+When input is piped (not a terminal), the shell runs in non-interactive mode:
+
+- Output defaults to `list` mode (override with `-m`)
+- No startup banner, history, or syntax highlighting
+- Exits with code 1 on query errors
+
+```bash
+echo "SELECT 1 + 2;" | tursodb -q
+```
+
+## Server Modes
+
+The CLI can also run as a server instead of an interactive shell.
+
+### MCP Server
+
+Start a [Model Context Protocol](https://modelcontextprotocol.io/) server, allowing AI assistants to interact with the database:
+
+```bash
+tursodb --mcp mydata.db
+```
+
+### Sync Server
+
+Start a sync server for database replication:
+
+```bash
+tursodb --sync-server 0.0.0.0:8080 mydata.db
+```
+

--- a/sql-reference/cli/shell-commands.mdx
+++ b/sql-reference/cli/shell-commands.mdx
@@ -1,0 +1,490 @@
+---
+title: Shell Commands
+description: Dot commands available in the Turso interactive SQL shell
+sidebarTitle: Shell Commands
+---
+
+# Shell Commands
+
+Dot commands are special commands available in the interactive shell. They start with a period (`.`) and do not require a trailing semicolon.
+
+```
+tursodb> .help
+```
+
+## Database & Navigation
+
+### .open
+
+Open a database file, optionally specifying a VFS backend.
+
+```
+.open <PATH> [VFS]
+```
+
+```
+tursodb> .open mydata.db
+tursodb> .open mydata.db memory
+```
+
+### .quit
+
+Exit the shell. Aliases: `.q`, `.qu`, `.qui`.
+
+```
+tursodb> .quit
+```
+
+### .exit
+
+Exit the shell with an optional return code. Aliases: `.ex`, `.exi`.
+
+```
+.exit [CODE]
+```
+
+```
+tursodb> .exit
+tursodb> .exit 1
+```
+
+### .cd
+
+Change the current working directory.
+
+```
+.cd <DIRECTORY>
+```
+
+```
+tursodb> .cd /tmp
+```
+
+## Schema Inspection
+
+### .tables
+
+List all tables in the database, optionally filtered by a pattern.
+
+```
+.tables [PATTERN]
+```
+
+```sql
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE departments (id INTEGER PRIMARY KEY, name TEXT);
+```
+
+```
+tursodb> .tables
+employees
+departments
+
+tursodb> .tables emp%
+employees
+```
+
+### .schema
+
+Display the CREATE statement for a table, or all tables if no argument is given.
+
+```
+.schema [TABLE]
+```
+
+```
+tursodb> .schema employees
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+
+tursodb> .schema
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE departments (id INTEGER PRIMARY KEY, name TEXT);
+```
+
+### .indexes
+
+Show index names, optionally filtered by table.
+
+```
+.indexes [TABLE]
+```
+
+```sql
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT, department TEXT);
+CREATE INDEX idx_dept ON employees(department);
+CREATE INDEX idx_name ON employees(name);
+```
+
+```
+tursodb> .indexes
+idx_dept
+idx_name
+
+tursodb> .indexes employees
+idx_dept
+idx_name
+```
+
+### .databases
+
+List all attached databases.
+
+```
+tursodb> .databases
+main: /path/to/mydata.db r/w
+```
+
+## Output Control
+
+### .mode
+
+Set the output display mode.
+
+```
+.mode <MODE>
+```
+
+| Mode | Description |
+|------|-------------|
+| `pretty` | Table with borders (default) |
+| `list` | Pipe-delimited values |
+| `line` | One column per line with column names |
+
+```
+tursodb> .mode list
+tursodb> SELECT 1 AS a, 2 AS b;
+1|2
+
+tursodb> .mode line
+tursodb> SELECT 1 AS a, 2 AS b;
+a = 1
+b = 2
+
+tursodb> .mode pretty
+tursodb> SELECT 1 AS a, 2 AS b;
+┌───┬───┐
+│ a │ b │
+├───┼───┤
+│ 1 │ 2 │
+└───┴───┘
+```
+
+### .headers
+
+Toggle column headers on or off in `list` mode.
+
+```
+.headers <on|off>
+```
+
+```
+tursodb> .mode list
+tursodb> .headers on
+tursodb> SELECT 1 AS x, 2 AS y;
+x|y
+1|2
+
+tursodb> .headers off
+tursodb> SELECT 1 AS x, 2 AS y;
+1|2
+```
+
+### .nullvalue
+
+Set the string displayed for NULL values in `list` mode.
+
+```
+.nullvalue <STRING>
+```
+
+```
+tursodb> .mode list
+tursodb> .nullvalue [NULL]
+tursodb> SELECT 1 AS a, NULL AS b;
+1|[NULL]
+```
+
+### .output
+
+Redirect query output to a file. Call with no argument or `stdout` to restore output to the terminal.
+
+```
+.output [PATH]
+```
+
+```
+tursodb> .output results.txt
+tursodb> SELECT * FROM employees;
+tursodb> .output
+tursodb> -- Output is back to the terminal
+```
+
+### .echo
+
+Toggle echo mode. When on, each SQL statement is printed before execution.
+
+```
+.echo <on|off>
+```
+
+```
+tursodb> .echo on
+tursodb> SELECT 42;
+SELECT 42;
+┌────┐
+│ 42 │
+├────┤
+│ 42 │
+└────┘
+```
+
+### .show
+
+Display current shell settings.
+
+```
+tursodb> .show
+Settings:
+Output mode: pretty
+DB: mydata.db
+Output: STDOUT
+Null value:
+CWD: /home/user
+Echo: off
+Headers: off
+```
+
+## Performance & Diagnostics
+
+### .timer
+
+Toggle query timing. When on, shows execution time and I/O statistics after each query.
+
+```
+.timer <on|off>
+```
+
+```
+tursodb> .timer on
+tursodb> SELECT 42;
+42
+Command stats:
+----------------------------
+total: 442 us (this includes parsing/coloring of cli app)
+
+query execution stats:
+----------------------------
+Execution: avg=4 us, total=8 us
+I/O: No samples available
+```
+
+### .stats
+
+Display database statistics. Use `on`/`off` to toggle automatic display after every query, or `--reset` to clear counters.
+
+```
+.stats [on|off] [--reset]
+```
+
+```
+tursodb> .stats
+Connection Metrics:
+  Total statements:     3
+  High-water marks:
+    Max VM steps:       19
+    Max rows read:      1
+
+Aggregate Statistics:
+Statement Metrics:
+  Row Operations:
+    Rows read:        1
+    Rows written:     2
+  Execution:
+    VM steps:         48
+    Instructions:     47
+  ...
+```
+
+### .opcodes
+
+Show VDBE (Virtual Database Engine) opcodes with descriptions. Optionally filter by opcode name.
+
+```
+.opcodes [OPCODE]
+```
+
+```
+tursodb> .opcodes Integer
+Integer
+-------
+The 64-bit integer value P1 is written into register P2. This is different
+from SQLite, where this opcode is used for 32-bit integers
+```
+
+### .vfslist
+
+List available Virtual File System modules.
+
+```
+tursodb> .vfslist
+Available VFS modules:
+memory
+syscall
+```
+
+## Data Import & Export
+
+### .dump
+
+Output the entire database as SQL statements that can recreate it.
+
+```
+tursodb> .dump
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+INSERT INTO "employees" VALUES(1,'Alice');
+INSERT INTO "employees" VALUES(2,'Bob');
+COMMIT;
+```
+
+<Info>
+The output of `.dump` can be piped into another Turso instance to recreate the database:
+
+```bash
+tursodb original.db ".dump" | tursodb -q clone.db
+```
+</Info>
+
+### .import
+
+Import data from a file into a table.
+
+```
+.import [--csv] [--skip N] [--verbose] <FILE> <TABLE>
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--csv` | on | Use comma as field separator and newline as record separator |
+| `--skip N` | 0 | Skip the first N rows (useful for skipping a header row) |
+| `--verbose` | off | Print progress information during import |
+
+```
+tursodb> CREATE TABLE people (name TEXT, age INTEGER);
+tursodb> .import --csv --skip 1 data.csv people
+tursodb> SELECT * FROM people;
+┌─────────┬─────┐
+│ name    │ age │
+├─────────┼─────┤
+│ Alice   │  30 │
+├─────────┼─────┤
+│ Bob     │  25 │
+├─────────┼─────┤
+│ Charlie │  35 │
+└─────────┴─────┘
+```
+
+Given a CSV file `data.csv`:
+
+```csv
+name,age
+Alice,30
+Bob,25
+Charlie,35
+```
+
+### .clone
+
+Clone the current database to a new file.
+
+```
+.clone <OUTPUT_FILE>
+```
+
+```
+tursodb> .clone backup.db
+employees... done
+```
+
+### .read
+
+Execute SQL statements from a file.
+
+```
+.read <PATH>
+```
+
+```
+tursodb> .read setup.sql
+```
+
+### .load
+
+Load an extension library.
+
+```
+.load <PATH>
+```
+
+```
+tursodb> .load ./liblimbo_regexp
+```
+
+<Info>
+Only Turso-native extensions can be loaded. SQLite `.so`/`.dll` loadable extensions are not supported. See the [Extensions](/sql-reference/extensions) documentation for available extensions.
+</Info>
+
+## Debugging
+
+### .dbtotxt
+
+Display raw database page contents in hex format. Useful for debugging storage-level issues.
+
+```
+.dbtotxt [--page PAGE_NO]
+```
+
+```
+tursodb> .dbtotxt --page 1
+| size 8192 pagesize 4096 filename :memory:
+| page 1 offset 0
+|      0: 53 51 4c 69 74 65 20 66 6f 72 6d 61 74 20 33 00   SQLite format 3.
+|     16: 10 00 02 02 00 40 20 20 00 00 00 01 00 00 00 02   .....@  ........
+...
+```
+
+### .dbconfig
+
+Print or set database configuration flags. Currently a no-op in Turso.
+
+```
+.dbconfig [CONFIG] [on|off]
+```
+
+## Documentation
+
+### .manual
+
+Display built-in manual pages for Turso features. Call with no argument to list all available manuals.
+
+```
+.manual [PAGE]
+```
+
+Aliases: `.man`.
+
+```
+tursodb> .manual
+# Turso Manual Pages
+
+Available manuals:
+  custom-types    Custom Types for STRICT Tables
+  cdc             Change Data Capture
+  encryption      At-Rest Database Encryption
+  vector          Vector Search
+  materialized-views  Live Materialized Views
+  mcp             Model Context Protocol server
+
+tursodb> .manual vector
+```

--- a/sql-reference/compatibility.mdx
+++ b/sql-reference/compatibility.mdx
@@ -25,6 +25,7 @@ These features extend Turso beyond SQLite compatibility:
 | [Encryption](/sql-reference/pragmas#encryption) | At-rest database encryption |
 | [Custom index methods](/sql-reference/statements/create-index#using-method) | CREATE INDEX ... USING for FTS and custom access methods |
 | stddev() | Standard deviation aggregate function |
+| [DEFAULT in VALUES](/sql-reference/statements/insert#default-keyword-in-values) | SQL-standard DEFAULT keyword in INSERT VALUES lists |
 
 ## See Also
 

--- a/sql-reference/data-types.mdx
+++ b/sql-reference/data-types.mdx
@@ -6,7 +6,7 @@ sidebarTitle: Data Types
 
 # Data Types
 
-Turso uses the same dynamic type system as SQLite, where values have types but columns do not enforce a single type (unless using STRICT tables). Every value stored in Turso belongs to one of five storage classes.
+Turso uses the same dynamic type system as SQLite, where values have types but columns do not enforce a single type (unless using STRICT tables). Every value stored in Turso belongs to one of five storage classes. Turso extends this system with [custom types](#custom-types), [composite types](#composite-types-struct-and-union), and [native array types](#array-types) for STRICT tables.
 
 ## Storage Classes
 
@@ -99,7 +99,7 @@ STRICT tables only allow these base type names:
 | ANY | Any storage class (disables type checking for this column) |
 
 <Info>
-**Turso Extension**: STRICT tables also accept [custom type](/sql-reference/statements/create-type) names. Custom types extend the type system with user-defined encoding, decoding, validation, and operator overloading.
+**Turso Extension**: STRICT tables also accept [custom type](/sql-reference/statements/create-type) names, [composite types](#composite-types-struct-and-union) (STRUCT and UNION), and [array types](#array-types). Any base type can be turned into an array column by appending `[]` to the type name (e.g., `INTEGER[]`, `TEXT[]`). Arrays, custom types, and composite types are Turso-specific features.
 </Info>
 
 ## Custom Types
@@ -165,6 +165,66 @@ INSERT INTO events VALUES (
 
 For the full custom types reference including ENCODE/DECODE, operators, parametric types, and validation, see [CREATE TYPE](/sql-reference/statements/create-type).
 
+### Composite Types: STRUCT and UNION
+
+Turso also supports composite types: **STRUCT** (named product type) and **UNION** (discriminated union). These let you store structured data in a single column and access it with dot notation.
+
+```sql
+-- STRUCT: group related fields, access with col.field
+CREATE TYPE point AS STRUCT(x INT, y INT);
+CREATE TABLE locations(id INT PRIMARY KEY, pos point) STRICT;
+INSERT INTO locations VALUES (1, struct_pack(10, 20));
+SELECT pos.x, pos.y FROM locations WHERE pos.x > 5;
+-- 10|20
+
+-- UNION: tagged variants, access with col.variant
+CREATE TYPE platform_id AS UNION(telegram INT, slack TEXT);
+CREATE TABLE contacts(id INT PRIMARY KEY, platform platform_id) STRICT;
+INSERT INTO contacts VALUES (1, union_value('telegram', 12345));
+INSERT INTO contacts VALUES (2, union_value('slack', 'U0ABC'));
+SELECT id, platform.telegram, platform.slack FROM contacts ORDER BY id;
+-- 1|12345|
+-- 2||U0ABC
+```
+
+For the full composite types reference, see [CREATE TYPE — Composite Types](/sql-reference/statements/create-type#composite-types-struct-and-union).
+
+## Array Types
+
+<Info>
+**Turso Extension**: Array types are a Turso-specific feature not available in SQLite. Array columns work only with STRICT tables.
+</Info>
+
+Array columns store ordered collections of values. Declare them by appending `[]` to any base type name:
+
+```sql
+CREATE TABLE sensors (
+    id INTEGER PRIMARY KEY,
+    readings REAL[],
+    labels TEXT[],
+    flags INTEGER[]
+) STRICT;
+```
+
+Multi-dimensional arrays are supported with multiple bracket pairs:
+
+```sql
+CREATE TABLE matrices (
+    id INTEGER PRIMARY KEY,
+    data INTEGER[][]
+) STRICT;
+```
+
+Arrays can be inserted using the `ARRAY[...]` constructor or as JSON text:
+
+```sql
+INSERT INTO sensors VALUES (1, ARRAY[1.5, 2.5, 3.5], '["a","b"]', '[0, 1, 1]');
+```
+
+Arrays are displayed as JSON arrays on output. Element types are validated against the declared base type — for example, an `INTEGER[]` column rejects non-numeric text elements.
+
+For the full set of array functions, operators, and subscript syntax, see [Array Functions](/sql-reference/functions/array).
+
 ### Inspecting Types
 
 List all available types (built-in and custom):
@@ -204,5 +264,6 @@ SELECT NULL IS NULL;    -- 1 (use IS to test for NULL)
 
 - [CREATE TABLE](/sql-reference/statements/create-table) for column definitions and constraints
 - [CREATE TYPE](/sql-reference/statements/create-type) for custom type definitions
+- [Array Functions](/sql-reference/functions/array) for array construction, manipulation, and operators
 - [Expressions](/sql-reference/expressions) for CAST expressions and type conversions
 - [Compatibility](/sql-reference/compatibility) for differences from SQLite

--- a/sql-reference/experimental-features.mdx
+++ b/sql-reference/experimental-features.mdx
@@ -13,12 +13,14 @@ Some Turso features are still experimental and must be explicitly enabled before
 | Feature | Flag | Description |
 |---------|------|-------------|
 | Views | `views` | [CREATE VIEW](/sql-reference/statements/create-view) and [CREATE MATERIALIZED VIEW](/sql-reference/statements/create-materialized-view) |
-| Custom Types | `custom_types` | [CREATE TYPE](/sql-reference/statements/create-type) and [DROP TYPE](/sql-reference/statements/drop-type) for STRICT tables |
+| Custom Types | `custom_types` | [CREATE TYPE](/sql-reference/statements/create-type), [DROP TYPE](/sql-reference/statements/drop-type), [CREATE DOMAIN](/sql-reference/statements/create-domain), and [DROP DOMAIN](/sql-reference/statements/drop-domain) for STRICT tables |
 | Triggers | `triggers` | [CREATE TRIGGER](/sql-reference/statements/create-trigger) and [DROP TRIGGER](/sql-reference/statements/drop-trigger) |
 | Encryption | `encryption` | At-rest encryption via [PRAGMA cipher / hexkey](/sql-reference/pragmas#encryption) |
 | Index Methods | `index_method` | [CREATE INDEX ... USING](/sql-reference/statements/create-index#using-clause) for FTS and custom index types |
 | Autovacuum | `autovacuum` | Automatic database file compaction |
+| Vacuum | `vacuum` | In-place [VACUUM](/sql-reference/statements/vacuum) compaction |
 | Attach | `attach` | [ATTACH DATABASE](/sql-reference/statements/attach-database) and [DETACH DATABASE](/sql-reference/statements/detach-database) |
+| Multi-Process WAL | `multiprocess_wal` | [Multi-Process Access](/sql-reference/multiprocess-access) — share a database file between OS processes via a shared WAL coordinator |
 
 ## CLI
 
@@ -37,6 +39,7 @@ tursodb \
   --experimental-triggers \
   --experimental-encryption \
   --experimental-index-method \
+  --experimental-vacuum \
   database.db
 ```
 
@@ -53,7 +56,9 @@ let db = Builder::new_local("database.db")
     .experimental_materialized_views(true)
     .experimental_custom_types(true)
     .experimental_index_method(true)
+    .experimental_vacuum(true)
     .experimental_attach(true)
+    .experimental_multiprocess_wal(true)
     .build()?;
 ```
 
@@ -66,7 +71,7 @@ import turso
 
 conn = turso.connect(
     "database.db",
-    experimental_features="views,triggers,custom_types",
+    experimental_features="views,triggers,custom_types,vacuum",
 )
 ```
 
@@ -78,7 +83,7 @@ Pass an array of feature strings to the `experimental` option:
 import { Database } from "@tursodatabase/libsql";
 
 const db = new Database("file:database.db", {
-    experimental: ["views", "triggers", "custom_types", "encryption"],
+    experimental: ["views", "triggers", "custom_types", "encryption", "vacuum"],
 });
 ```
 
@@ -89,14 +94,14 @@ Set the `ExperimentalFeatures` field as a comma-separated string:
 ```go
 db, err := turso.NewDatabase(turso.TursoDatabaseConfig{
     Path: "database.db",
-    ExperimentalFeatures: "views,triggers,custom_types",
+    ExperimentalFeatures: "views,triggers,custom_types,vacuum",
 })
 ```
 
 The Go driver also supports DSN query parameters:
 
 ```go
-db, err := sql.Open("turso", "database.db?experimental=views,triggers")
+db, err := sql.Open("turso", "database.db?experimental=views,triggers,vacuum")
 ```
 
 ## Java SDK

--- a/sql-reference/expressions.mdx
+++ b/sql-reference/expressions.mdx
@@ -112,6 +112,33 @@ All comparison operators return `1` (true), `0` (false), or `NULL` (if either op
 |----------|-------------|---------|--------|
 | `\|\|` | Concatenation | `'hello' \|\| ' ' \|\| 'world'` | `'hello world'` |
 
+When either operand is an array, `||` performs array concatenation instead. See [Array Operators](#array-operators).
+
+### Array Operators
+
+<Info>
+**Turso Extension**: Array operators are a Turso-specific feature not available in SQLite.
+</Info>
+
+| Operator | Description | Example | Result |
+|----------|-------------|---------|--------|
+| `@>` | Contains all | `ARRAY[1,2,3] @> ARRAY[1,2]` | `1` |
+| `&&` | Overlaps | `ARRAY[1,2,3] && ARRAY[3,4,5]` | `1` |
+| `\|\|` | Array concat | `ARRAY[1,2] \|\| ARRAY[3,4]` | `[1,2,3,4]` |
+| `=`, `!=`, `<`, `>`, `<=`, `>=` | Comparison | `ARRAY[1,2] < ARRAY[1,3]` | `1` |
+
+The `@>` operator tests if the left array contains all elements of the right array. The `&&` operator tests if two arrays share any common elements. Both return `1` (true) or `0` (false).
+
+Array comparison is element-wise from left to right. If all compared elements are equal, the shorter array is considered less than the longer one.
+
+```sql
+SELECT ARRAY[1,2,3] @> ARRAY[1,3];     -- 1 (contains both 1 and 3)
+SELECT ARRAY[1,2] && ARRAY[3,4];       -- 0 (no common elements)
+SELECT ARRAY[1,2] < ARRAY[1,2,3];      -- 1 (shorter is less)
+```
+
+For the full reference, see [Array Functions](/sql-reference/functions/array).
+
 ## CAST Expression
 
 The CAST expression converts a value to a specified type.
@@ -402,7 +429,7 @@ Operators are evaluated in the following order (highest precedence first):
 | 3 | `*`, `/` |
 | 4 | `+`, `-` |
 | 5 | `<<`, `>>`, `&`, `\|` |
-| 6 | `<`, `<=`, `>`, `>=` |
+| 6 | `<`, `<=`, `>`, `>=`, `@>`, `&&` |
 | 7 | `=`, `==`, `!=`, `<>`, `IS`, `IS NOT`, `IS DISTINCT FROM`, `IN`, `LIKE`, `GLOB`, `REGEXP`, `BETWEEN` |
 | 8 | `NOT` |
 | 9 | `AND` |

--- a/sql-reference/functions/aggregate.mdx
+++ b/sql-reference/functions/aggregate.mdx
@@ -14,6 +14,7 @@ All standard aggregate functions ignore NULL values (except `count(*)`). If ever
 
 | Function | Return Type | Description |
 |----------|-------------|-------------|
+| `array_agg(X)` | BLOB (array) | Collects all values of X into an array (Turso extension) |
 | `avg(X)` | REAL | Average of all non-NULL values of X |
 | `count(X)` | INTEGER | Count of rows where X is not NULL |
 | `count(*)` | INTEGER | Count of all rows in the group |
@@ -350,6 +351,47 @@ ORDER BY region, id;
 | 3 | South | 150.0 | 150.0 | 3 |
 | 4 | South | NULL | 150.0 | 3 |
 | 6 | South | 175.0 | 325.0 | 3 |
+
+## Turso Extension: array_agg(X)
+
+<Info>
+`array_agg(X)` is a Turso extension and is not part of standard SQLite. It is available by default in Turso without loading any additional extensions.
+</Info>
+
+```sql
+array_agg(X)
+```
+
+Collects all values of X (including NULLs) into an array. Returns NULL if the group is empty.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| X | any | The expression whose values to collect into an array |
+
+**Return type:** BLOB (array)
+
+```sql
+SELECT array_agg(name) FROM users;
+-- ["Alice","Bob","Charlie"]
+
+SELECT department, array_agg(name) FROM employees GROUP BY department;
+```
+
+| department | array_agg(name) |
+|------------|-----------------|
+| Engineering | ["Alice","Bob"] |
+| Sales | ["Charlie","Diana","Eve"] |
+
+```sql
+-- Control ordering with a subquery
+SELECT array_agg(name) FROM (SELECT name FROM users ORDER BY name);
+
+-- Combine with array_length
+SELECT array_length(array_agg(name)) FROM users;
+-- 3
+```
+
+For more array functions, see [Array Functions](/sql-reference/functions/array).
 
 ## Turso Extension: stddev(X)
 

--- a/sql-reference/functions/array.mdx
+++ b/sql-reference/functions/array.mdx
@@ -1,0 +1,661 @@
+---
+title: Array Functions
+description: Create, manipulate, and query array values
+sidebarTitle: Array
+---
+
+# Array Functions
+
+<Info>
+**Turso Extension**: Array types and functions are a Turso-specific feature for working with ordered collections directly in SQL. These functions are not part of the SQLite standard. Array columns require [STRICT tables](/sql-reference/statements/create-table#strict-tables).
+</Info>
+
+Turso provides built-in support for array columns and a set of functions for constructing, querying, and transforming arrays. Arrays are stored internally as compact record-format BLOBs and displayed as JSON arrays on output.
+
+---
+
+## Array Construction
+
+### ARRAY[] Literal
+
+Constructs an array from a list of expressions.
+
+```sql
+ARRAY[expr1, expr2, ...]
+```
+
+```sql
+SELECT ARRAY[1, 2, 3];
+-- [1,2,3]
+
+SELECT ARRAY['hello', 'world'];
+-- ["hello","world"]
+
+SELECT ARRAY[];
+-- []
+```
+
+Arrays can also be inserted as JSON text:
+
+```sql
+CREATE TABLE t (id INTEGER PRIMARY KEY, tags TEXT[]) STRICT;
+
+INSERT INTO t VALUES (1, ARRAY['a', 'b', 'c']);
+INSERT INTO t VALUES (2, '["x", "y", "z"]');
+
+SELECT tags FROM t ORDER BY id;
+-- ["a","b","c"]
+-- ["x","y","z"]
+```
+
+### string_to_array
+
+Splits a string into an array using a delimiter.
+
+```sql
+string_to_array(text, delimiter)
+string_to_array(text, delimiter, null_string)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | TEXT | The string to split |
+| `delimiter` | TEXT | The delimiter to split on. If NULL, splits into individual characters |
+| `null_string` | TEXT | Optional. Elements matching this string are replaced with NULL |
+
+**Returns:** BLOB -- an array value.
+
+```sql
+SELECT string_to_array('one,two,three', ',');
+-- ["one","two","three"]
+
+SELECT string_to_array('hello', NULL);
+-- ["h","e","l","l","o"]
+
+SELECT string_to_array('a,NULL,b', ',', 'NULL');
+-- ["a",null,"b"]
+```
+
+---
+
+## Element Access
+
+### Subscript Operator []
+
+Access individual elements using zero-based indexing. Returns NULL for out-of-bounds or negative indices.
+
+```sql
+array_expr[index]
+```
+
+```sql
+CREATE TABLE t (id INTEGER PRIMARY KEY, items TEXT[]) STRICT;
+INSERT INTO t VALUES (1, '["first", "second", "third"]');
+
+SELECT items[0], items[1], items[2] FROM t;
+-- first|second|third
+
+SELECT items[100] FROM t;
+-- NULL
+
+SELECT items[-1] FROM t;
+-- NULL
+```
+
+Subscripts can be chained for multi-dimensional arrays:
+
+```sql
+CREATE TABLE m (id INTEGER PRIMARY KEY, matrix INTEGER[][]) STRICT;
+INSERT INTO m VALUES (1, ARRAY[ARRAY[1,2], ARRAY[3,4]]);
+
+SELECT matrix[0][1] FROM m;
+-- 2
+
+SELECT matrix[1][0] FROM m;
+-- 3
+```
+
+### Slice Operator [start:end]
+
+Extract a sub-array using half-open range `[start, end)`.
+
+```sql
+array_expr[start:end]
+```
+
+```sql
+CREATE TABLE t (id INTEGER PRIMARY KEY, tags TEXT[]) STRICT;
+INSERT INTO t VALUES (1, ARRAY['a','b','c','d']);
+
+SELECT tags[1:3] FROM t;
+-- ["b","c"]
+```
+
+---
+
+## Scalar Functions
+
+### array_length
+
+Returns the number of elements in an array.
+
+```sql
+array_length(array)
+array_length(array, dimension)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array` | BLOB/TEXT | The array to measure |
+| `dimension` | INTEGER | Optional. Currently only dimension 1 is supported |
+
+**Returns:** INTEGER -- the number of elements. NULL if the input is NULL.
+
+```sql
+SELECT array_length(ARRAY[10, 20, 30]);
+-- 3
+
+SELECT array_length('[]');
+-- 0
+
+SELECT array_length(NULL);
+-- NULL
+```
+
+### array_append
+
+Appends an element to the end of an array.
+
+```sql
+array_append(array, element)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array` | BLOB/TEXT | The array to append to. If NULL, a new single-element array is created |
+| `element` | any | The element to append |
+
+**Returns:** BLOB -- a new array with the element appended.
+
+```sql
+SELECT array_append('[1, 2]', 3);
+-- [1,2,3]
+
+SELECT array_append('[]', 'x');
+-- ["x"]
+
+SELECT array_append(NULL, 'x');
+-- ["x"]
+```
+
+### array_prepend
+
+Prepends an element to the beginning of an array.
+
+```sql
+array_prepend(element, array)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `element` | any | The element to prepend |
+| `array` | BLOB/TEXT | The array to prepend to |
+
+**Returns:** BLOB -- a new array with the element prepended.
+
+```sql
+SELECT array_prepend('z', '["a", "b"]');
+-- ["z","a","b"]
+```
+
+### array_cat
+
+Concatenates two arrays.
+
+```sql
+array_cat(array1, array2)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array1` | BLOB/TEXT | The first array |
+| `array2` | BLOB/TEXT | The second array |
+
+**Returns:** BLOB -- a new array containing all elements from both arrays.
+
+```sql
+SELECT array_cat('[1, 2]', '[3, 4]');
+-- [1,2,3,4]
+
+SELECT array_cat('[]', '[1, 2]');
+-- [1,2]
+```
+
+The `||` operator also works for array concatenation:
+
+```sql
+CREATE TABLE t (id INTEGER PRIMARY KEY, tags TEXT[]) STRICT;
+INSERT INTO t VALUES (1, ARRAY['a', 'b']);
+
+-- Append element
+SELECT tags || 'c' FROM t;
+-- ["a","b","c"]
+
+-- Prepend element
+SELECT 'z' || tags FROM t;
+-- ["z","a","b"]
+
+-- Concatenate arrays
+SELECT tags || ARRAY['x', 'y'] FROM t;
+-- ["a","b","x","y"]
+```
+
+### array_remove
+
+Removes all occurrences of an element from an array.
+
+```sql
+array_remove(array, element)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array` | BLOB/TEXT | The array to remove from |
+| `element` | any | The element to remove |
+
+**Returns:** BLOB -- a new array with all occurrences of the element removed.
+
+```sql
+SELECT array_remove('[1, 2, 3, 2, 1]', 2);
+-- [1,3,1]
+
+SELECT array_remove('[1, 2, 3]', 99);
+-- [1,2,3]
+```
+
+### array_contains
+
+Tests whether an array contains a specific element.
+
+```sql
+array_contains(array, element)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array` | BLOB/TEXT | The array to search |
+| `element` | any | The element to search for |
+
+**Returns:** INTEGER -- 1 if found, 0 if not found.
+
+```sql
+SELECT array_contains('[1, 2, 3]', 2);
+-- 1
+
+SELECT array_contains('[1, 2, 3]', 5);
+-- 0
+```
+
+### array_position
+
+Returns the zero-based index of the first occurrence of an element.
+
+```sql
+array_position(array, element)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array` | BLOB/TEXT | The array to search |
+| `element` | any | The element to find |
+
+**Returns:** INTEGER -- the zero-based index, or NULL if not found.
+
+```sql
+SELECT array_position('[10, 20, 30]', 20);
+-- 1
+
+SELECT array_position('[10, 20, 30]', 10);
+-- 0
+
+SELECT array_position('[10, 20, 30]', 99);
+-- NULL
+```
+
+### array_slice
+
+Extracts a sub-array by index range.
+
+```sql
+array_slice(array, start, end)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array` | BLOB/TEXT | The source array |
+| `start` | INTEGER | Start index (zero-based, inclusive). NULL means 0 |
+| `end` | INTEGER | End index (exclusive) |
+
+**Returns:** BLOB -- a new array containing elements from `start` to `end - 1`.
+
+```sql
+SELECT array_slice('[1, 2, 3, 4]', 1, 3);
+-- [2,3]
+
+SELECT array_slice('[1, 2, 3, 4]', NULL, 2);
+-- [1,2]
+```
+
+### array_to_string
+
+Joins array elements into a string with a delimiter.
+
+```sql
+array_to_string(array, delimiter)
+array_to_string(array, delimiter, null_string)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array` | BLOB/TEXT | The array to join |
+| `delimiter` | TEXT | The separator between elements |
+| `null_string` | TEXT | Optional. Replacement text for NULL elements. If omitted, NULLs are skipped |
+
+**Returns:** TEXT -- the joined string.
+
+```sql
+SELECT array_to_string('[1, 2, 3]', ',');
+-- 1,2,3
+
+SELECT array_to_string('["hello", "world"]', ' ');
+-- hello world
+
+SELECT array_to_string('[1, null, 3]', ',');
+-- 1,3
+
+SELECT array_to_string('[1, null, 3]', ',', 'N/A');
+-- 1,N/A,3
+```
+
+### array_contains_all
+
+Tests whether one array contains all elements of another.
+
+```sql
+array_contains_all(haystack, needles)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `haystack` | BLOB/TEXT | The array to search in |
+| `needles` | BLOB/TEXT | The array of elements to search for |
+
+**Returns:** INTEGER -- 1 if all elements of `needles` are found in `haystack`, 0 otherwise.
+
+```sql
+SELECT array_contains_all('[1, 2, 3, 4, 5]', '[2, 4]');
+-- 1
+
+SELECT array_contains_all('[1, 2, 3]', '[2, 4]');
+-- 0
+
+SELECT array_contains_all('[1, 2, 3]', '[]');
+-- 1
+```
+
+The `@>` operator is an alias for this function. See [Array Operators](/sql-reference/expressions#array-operators).
+
+### array_overlap
+
+Tests whether two arrays share any common elements.
+
+```sql
+array_overlap(array1, array2)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `array1` | BLOB/TEXT | The first array |
+| `array2` | BLOB/TEXT | The second array |
+
+**Returns:** INTEGER -- 1 if any element appears in both arrays, 0 otherwise.
+
+```sql
+SELECT array_overlap('[1, 2, 3]', '[3, 4, 5]');
+-- 1
+
+SELECT array_overlap('[1, 2, 3]', '[4, 5, 6]');
+-- 0
+
+SELECT array_overlap('[]', '[1, 2]');
+-- 0
+```
+
+`array_overlaps` is accepted as an alias. The `&&` operator is also an alias. See [Array Operators](/sql-reference/expressions#array-operators).
+
+---
+
+## Aggregate Function
+
+### array_agg
+
+Collects values from a group of rows into an array.
+
+```sql
+array_agg(expression)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `expression` | any | The value to collect. NULL values are included |
+
+**Returns:** BLOB -- an array containing one element per row in the group. Returns NULL for empty groups.
+
+```sql
+CREATE TABLE t (grp TEXT, val TEXT);
+INSERT INTO t VALUES ('x', 'a'), ('x', 'b'), ('y', 'c'), ('y', 'd'), ('y', 'e');
+
+SELECT grp, array_agg(val) FROM t GROUP BY grp ORDER BY grp;
+```
+
+| grp | array_agg(val) |
+|-----|----------------|
+| x | ["a","b"] |
+| y | ["c","d","e"] |
+
+```sql
+-- Control order with a subquery
+SELECT array_agg(val) FROM (SELECT val FROM t ORDER BY val);
+-- ["a","b","c","d","e"]
+
+-- Combine with array_length
+SELECT array_length(array_agg(val)) FROM t;
+-- 5
+```
+
+---
+
+## Array Operators
+
+### Containment: @>
+
+Tests whether the left array contains all elements of the right array. Equivalent to `array_contains_all(left, right)`.
+
+```sql
+array1 @> array2
+```
+
+```sql
+SELECT ARRAY[1,2,3] @> ARRAY[1,2];
+-- 1
+
+SELECT ARRAY[1,2,3] @> ARRAY[1,4];
+-- 0
+```
+
+### Overlap: &&
+
+Tests whether two arrays share any common elements. Equivalent to `array_overlap(left, right)`.
+
+```sql
+array1 && array2
+```
+
+```sql
+SELECT ARRAY[1,2,3] && ARRAY[3,4,5];
+-- 1
+
+SELECT ARRAY[1,2] && ARRAY[3,4];
+-- 0
+```
+
+### Comparison: =, !=, &lt;, >, &lt;=, >=
+
+Arrays support element-wise comparison. Elements are compared pairwise from left to right; if all compared elements are equal, the shorter array is considered less than the longer one.
+
+```sql
+SELECT ARRAY[1,2,3] = ARRAY[1,2,3];   -- 1
+SELECT ARRAY[1,2] < ARRAY[1,3];       -- 1
+SELECT ARRAY[1,2] < ARRAY[1,2,3];     -- 1 (shorter is less)
+```
+
+### Concatenation: ||
+
+When either operand is an array, `||` performs array concatenation or element append/prepend instead of string concatenation.
+
+```sql
+SELECT ARRAY[1,2] || ARRAY[3,4];  -- [1,2,3,4]  (array + array)
+SELECT ARRAY[1,2] || 3;           -- [1,2,3]    (append element)
+SELECT 0 || ARRAY[1,2];           -- [0,1,2]    (prepend element)
+```
+
+### Using operators in WHERE clauses
+
+```sql
+CREATE TABLE docs (id INTEGER PRIMARY KEY, tags TEXT[]) STRICT;
+INSERT INTO docs VALUES (1, ARRAY['sql','database','tutorial']);
+INSERT INTO docs VALUES (2, ARRAY['rust','systems']);
+INSERT INTO docs VALUES (3, ARRAY['sql','rust']);
+
+-- Find docs tagged with both 'sql' and 'rust'
+SELECT id FROM docs WHERE tags @> ARRAY['sql','rust'];
+-- 3
+
+-- Find docs with any overlap with a set of tags
+SELECT id FROM docs WHERE tags && ARRAY['database','systems'] ORDER BY id;
+-- 1
+-- 2
+```
+
+---
+
+## Subscript Assignment
+
+Array elements can be updated individually using subscript syntax in UPDATE statements.
+
+```sql
+UPDATE table SET column[index] = value WHERE ...;
+```
+
+```sql
+CREATE TABLE t (id INTEGER PRIMARY KEY, tags TEXT[]) STRICT;
+INSERT INTO t VALUES (1, ARRAY['a','b','c']);
+
+UPDATE t SET tags[0] = 'X' WHERE id = 1;
+SELECT tags FROM t;
+-- ["X","b","c"]
+
+-- Multiple subscripts in one UPDATE
+UPDATE t SET tags[0] = 'A', tags[2] = 'C' WHERE id = 1;
+SELECT tags FROM t;
+-- ["A","b","C"]
+```
+
+Out-of-bounds assignments are silently ignored (the array is unchanged).
+
+---
+
+## Examples
+
+### Tagging system
+
+```sql
+CREATE TABLE articles (
+    id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    tags TEXT[]
+) STRICT;
+
+INSERT INTO articles VALUES (1, 'Getting Started with SQL', ARRAY['sql','beginner','tutorial']);
+INSERT INTO articles VALUES (2, 'Advanced Indexing', ARRAY['sql','performance','advanced']);
+INSERT INTO articles VALUES (3, 'Rust for Systems', ARRAY['rust','systems']);
+
+-- Find articles tagged 'sql'
+SELECT title FROM articles WHERE array_contains(tags, 'sql');
+
+-- Find articles with both 'sql' and 'advanced'
+SELECT title FROM articles WHERE tags @> ARRAY['sql','advanced'];
+-- Advanced Indexing
+
+-- Count tags per article
+SELECT title, array_length(tags) AS tag_count FROM articles;
+
+-- Collect all unique tags
+SELECT array_agg(DISTINCT tag) FROM (
+    SELECT array_to_string(tags, ',') AS tag FROM articles
+);
+```
+
+### Multi-dimensional arrays
+
+```sql
+CREATE TABLE matrices (
+    id INTEGER PRIMARY KEY,
+    data INTEGER[][]
+) STRICT;
+
+INSERT INTO matrices VALUES (1, ARRAY[ARRAY[1,2,3], ARRAY[4,5,6]]);
+
+-- Access a row
+SELECT data[0] FROM matrices WHERE id = 1;
+-- [1,2,3]
+
+-- Access a single element
+SELECT data[1][2] FROM matrices WHERE id = 1;
+-- 6
+
+-- Get number of rows
+SELECT array_length(data) FROM matrices WHERE id = 1;
+-- 2
+```
+
+### Type checking
+
+Array columns in STRICT tables validate element types on insert and update:
+
+```sql
+CREATE TABLE scores (id INTEGER PRIMARY KEY, vals INTEGER[]) STRICT;
+
+-- OK: exact integers
+INSERT INTO scores VALUES (1, '[1, 2, 3]');
+
+-- OK: floats that are exact integers are coerced
+INSERT INTO scores VALUES (2, '[1.0, 2.0]');
+
+-- OK: numeric strings are coerced
+INSERT INTO scores VALUES (3, '["42", "100"]');
+
+-- Error: non-numeric string in INTEGER array
+INSERT INTO scores VALUES (4, '["hello"]');
+-- Error: cannot store TEXT value in INTEGER
+
+-- NULL elements are always allowed
+INSERT INTO scores VALUES (5, '[1, null, 3]');
+```
+
+## See Also
+
+- [Data Types](/sql-reference/data-types#array-types) for array column type declarations
+- [CREATE TABLE](/sql-reference/statements/create-table) for STRICT table requirements
+- [Expressions](/sql-reference/expressions#array-operators) for array operator syntax
+- [Aggregate Functions](/sql-reference/functions/aggregate) for `array_agg`

--- a/sql-reference/multiprocess-access.mdx
+++ b/sql-reference/multiprocess-access.mdx
@@ -1,0 +1,161 @@
+---
+title: Multi-Process Access
+description: Share a Turso database file between multiple OS processes using the experimental multiprocess WAL coordinator
+sidebarTitle: Multi-Process Access
+---
+
+# Multi-Process Access
+
+<Warning>
+Multi-process access is **experimental**. The on-disk coordination format and the public API may change between releases. Do not rely on the format for long-term storage across Turso versions.
+</Warning>
+
+By default, a Turso database file is opened by a single OS process. Multiple threads and connections within that process can safely share the database, but opening the same file from a second process is rejected with a locking error.
+
+Multi-process access removes that restriction. When the `multiprocess_wal` feature is enabled, several processes can open the same `.db` file concurrently and coordinate WAL reads, writes, and checkpoints through a shared memory file.
+
+## When to Use It
+
+Enable multi-process access when you need:
+
+- Multiple independent OS processes (workers, sidecars, CLI + embedded app) to read and write the same database file without a server tier.
+- Zero-downtime deploys where an old process and a new process briefly overlap on the same database.
+- Process-per-connection deployments that need stronger isolation than threads.
+
+For single-process applications — including multi-threaded servers using a connection pool — the default mode is faster and requires no configuration.
+
+## How It Works
+
+When multi-process access is enabled, Turso creates an additional sibling file next to the database:
+
+| File | Purpose |
+|------|---------|
+| `mydb.db` | The database file (unchanged). |
+| `mydb.db-wal` | The write-ahead log (unchanged). |
+| `mydb.db-tshm` | Turso shared memory. Memory-mapped coordinator that tracks WAL state, the active writer, the active checkpointer, reader slots, and a shared page-to-frame index. |
+
+All participating processes mmap the `.tshm` file and coordinate through:
+
+- A **single-writer** slot. At most one process across the cluster holds the writer lock at any time.
+- A **single-checkpointer** slot. Checkpointing is serialized across processes.
+- A bounded set of **reader slots**. Each active read transaction pins a WAL frame so it is not overwritten by concurrent writers or reclaimed by the checkpointer.
+- A shared **frame index** so readers in any process can resolve a page number to the latest WAL frame without scanning the WAL from the beginning.
+
+Cross-process byte-range locks on the `.tshm` file (OFD locks on Linux, `fcntl` on macOS) gate ownership transitions; the mmap regions provide the fast path for metadata lookups.
+
+## Requirements
+
+Multi-process WAL is only available when all of the following hold:
+
+- **Platform**:  64-bit Unix-like OS (Linux, macOS, Android, other supported Unix systems). On Windows, WASM, and 32-bit targets the flag is accepted but has no effect, and the database opens in single-process mode.
+- **IO backend**: The active IO backend must implement shared WAL coordination. The default file-backed backends do; memory-only and some custom VFSes do not.
+- **Filesystem**: The database must live on a local filesystem that implements POSIX byte-range locks and mmap correctly. The following filesystems are **explicitly rejected** because shared mmap coordination is not safe on them:
+
+  | Filesystem | Reason |
+  |------------|--------|
+  | NFS | Advisory lock semantics diverge across clients |
+  | CIFS / SMB2 | Same as above; mmap coherence is not guaranteed |
+  | CephFS | Distributed cache semantics |
+  | GFS2 | Cluster filesystem; not validated |
+  | Lustre | Distributed; not validated |
+  | OCFS2 | Cluster filesystem; not validated |
+  | AFS, CODA, NCP, 9P (v9fs) | Network/legacy filesystems with unreliable mmap+lock semantics |
+
+  Opening a database on any of these filesystems with `multiprocess_wal` enabled returns `InvalidArgument`.
+
+- **Not in-memory**: `:memory:` and `file::memory:` paths are rejected — shared coordination requires a durable file.
+
+## Enabling Multi-Process Access
+
+### CLI
+
+Pass `--experimental-multiprocess-wal`:
+
+```bash
+tursodb --experimental-multiprocess-wal mydb.db
+```
+
+Every `tursodb` (or SDK) process that opens `mydb.db` at the same time must pass the flag. Mixing modes is rejected — see [Mixing Modes](#mixing-modes).
+
+### Rust SDK
+
+```rust
+use turso::Builder;
+
+let db = Builder::new_local("mydb.db")
+    .experimental_multiprocess_wal(true)
+    .build()?;
+```
+
+### JavaScript / Node.js SDK
+
+```typescript
+import { Database } from "@tursodatabase/libsql";
+
+const db = new Database("file:mydb.db", {
+    experimental: ["multiprocess_wal"],
+});
+```
+
+### Python SDK
+
+```python
+import turso
+
+conn = turso.connect(
+    "mydb.db",
+    experimental_features="multiprocess_wal",
+)
+```
+
+### Go SDK
+
+```go
+db, err := turso.NewDatabase(turso.TursoDatabaseConfig{
+    Path:                 "mydb.db",
+    ExperimentalFeatures: "multiprocess_wal",
+})
+```
+
+Or via DSN:
+
+```go
+db, err := sql.Open("turso", "mydb.db?experimental=multiprocess_wal")
+```
+
+## Concurrency Model
+
+Multi-process access preserves Turso's WAL concurrency guarantees across processes:
+
+- **Writers are serialized across processes.** At any instant, at most one process (and one connection within that process) holds the writer slot. Writers in other processes block until it is released.
+- **Readers never block writers.** Each active read transaction registers a reader slot that pins its snapshot's max-frame. A reader in one process cannot be invalidated by a writer in another.
+- **Checkpointing is serialized across processes.** A single checkpointer truncates the WAL; readers pinning older frames prevent premature reclamation regardless of which process owns them.
+- **Snapshots are stable.** Each read transaction observes a consistent snapshot, even if a concurrent process commits new frames.
+
+Schema changes (DDL) made in one process are picked up by other processes on their next statement via the existing schema refresh path — prepared statements in sibling processes may return `SchemaUpdated` and re-prepare, just as they do across connections within a single process.
+
+## Mixing Modes
+
+The database cannot be open simultaneously in single-process mode from one process and multi-process mode from another. The open path probes for an incompatible live opener and fails fast:
+
+- Opening without `multiprocess_wal` while another process holds a live `.tshm` authority fails with:
+  > Database is already open with experimental multiprocess WAL in another process
+- Opening with `multiprocess_wal` while another process holds the legacy exclusive DB-file lock fails with:
+  > Database is already open without experimental multiprocess WAL in another process
+
+To switch modes, close all existing connections to the database, then reopen with the desired configuration. The `.tshm` file may be left in place — Turso reuses it on the next multi-process open and rebuilds its state from the WAL if necessary.
+
+Read-only opens are advisory: if `multiprocess_wal` is requested on a read-only open and no `.tshm` file exists, Turso falls back to the legacy read-only WAL path rather than failing. This lets read-only tooling work against a database that was closed cleanly by a single-process writer.
+
+## Limitations
+
+- The `.tshm` file format is versioned and may change in future releases. A format bump invalidates existing `.tshm` files — Turso recreates them on open; it does not attempt cross-version migration.
+- Attached databases (via [ATTACH DATABASE](/sql-reference/statements/attach-database)) inherit the multi-process setting of the main connection.
+- The feature is not yet supported under MVCC (`BEGIN CONCURRENT`). Use either MVCC within a single process or multi-process WAL with the default isolation model, not both.
+- The concurrent-simulator and stress tests for multi-process mode run only on 64-bit Unix targets. Windows, WASM, and 32-bit builds silently ignore the flag.
+
+## See Also
+
+- [Experimental Features](/sql-reference/experimental-features) — how to enable experimental features across all surfaces
+- [Transactions](/sql-reference/statements/transactions) — WAL concurrency model and `BEGIN CONCURRENT`
+- [Compatibility](/sql-reference/compatibility) — SQLite compatibility matrix

--- a/sql-reference/pragmas.mdx
+++ b/sql-reference/pragmas.mdx
@@ -219,7 +219,7 @@ PRAGMA journal_mode = wal;
 Turso supports WAL (Write-Ahead Logging) mode. Rollback journal modes (DELETE, TRUNCATE, PERSIST, MEMORY) are not supported.
 
 <Info>
-**Turso Extension**: Turso supports an MVCC journal mode for concurrent writes:
+**Turso Extension**: Turso supports an experimental MVCC journal mode for concurrent writes:
 
 ```sql
 PRAGMA journal_mode = mvcc;

--- a/sql-reference/statements/attach-database.mdx
+++ b/sql-reference/statements/attach-database.mdx
@@ -29,7 +29,7 @@ ATTACH opens the database file at `filename` and makes its tables accessible thr
 Every connection has a built-in schema named `main` for its primary database. The names `main` and `temp` are reserved and cannot be used as schema names for attached databases.
 
 <Info>
-This feature is experimental and must be [enabled before use](/sql-reference/experimental-features). Attached databases are currently **read-only**. All write operations (INSERT, UPDATE, DELETE, CREATE TABLE, etc.) on tables in attached databases will fail. Use ATTACH for cross-database queries and data migration reads.
+This feature is experimental and must be [enabled before use](/sql-reference/experimental-features). Attached databases support both read and write operations (INSERT, UPDATE, DELETE, CREATE TABLE, etc.). The attached database's journal mode must match the main database's journal mode (e.g., both WAL or both MVCC).
 </Info>
 
 ## Examples

--- a/sql-reference/statements/create-domain.mdx
+++ b/sql-reference/statements/create-domain.mdx
@@ -1,0 +1,297 @@
+---
+title: CREATE DOMAIN
+description: Define a named constraint wrapper over a base type for use in STRICT tables
+sidebarTitle: CREATE DOMAIN
+---
+
+# CREATE DOMAIN
+
+<Info>
+**Turso Extension**: CREATE DOMAIN is a Turso-specific statement not available in standard SQLite. Domains require STRICT tables and the custom types experimental feature. This feature must be [enabled before use](/sql-reference/experimental-features).
+</Info>
+
+The CREATE DOMAIN statement defines a named type alias with optional constraints. Unlike [CREATE TYPE](/sql-reference/statements/create-type), a domain does not specify custom ENCODE/DECODE logic or OPERATORs. Instead, a domain adds NOT NULL and CHECK constraints on top of a base type, and values are stored using the base type's native storage format.
+
+## Syntax
+
+```sql
+CREATE DOMAIN [IF NOT EXISTS] domain-name AS base-type
+    [DEFAULT default-expr]
+    [NOT NULL]
+    [[CONSTRAINT constraint-name] CHECK (expr)]
+    ...;
+```
+
+## Description
+
+A domain wraps a base type with validation constraints. When a value is written to a column of a domain type, the CHECK constraints and NOT NULL restriction (if any) are verified. If validation passes, the value is stored using the base type's native format. When a value is read, it is returned unchanged.
+
+Domains are transparent to the query engine for operations like ORDER BY, indexing, arithmetic, and aggregation. A domain column behaves exactly like a column of its base type, with the addition of input validation.
+
+Domains work only with STRICT tables. Using a domain name in a non-STRICT table has no effect.
+
+## Clauses
+
+### IF NOT EXISTS
+
+Suppresses the error that would occur if a domain with the same name already exists. The existing domain is left unchanged.
+
+```sql
+CREATE DOMAIN IF NOT EXISTS positive_int AS integer CHECK (value > 0);
+```
+
+### AS base-type
+
+Specifies the underlying type. The base type can be a primitive type (`integer`, `real`, `text`, `blob`) or another domain, allowing domains to be layered.
+
+```sql
+CREATE DOMAIN percentage AS integer
+    CHECK (value >= 0)
+    CHECK (value <= 100);
+```
+
+### DEFAULT
+
+Sets a default value for columns of this domain type. A column-level DEFAULT overrides the domain-level DEFAULT.
+
+```sql
+CREATE DOMAIN status AS text DEFAULT 'active';
+
+CREATE TABLE accounts (
+    id INTEGER PRIMARY KEY,
+    state status
+) STRICT;
+
+INSERT INTO accounts(id) VALUES (1);
+SELECT state FROM accounts;
+-- active
+```
+
+### NOT NULL
+
+Adds a NOT NULL constraint to the domain. Any attempt to insert or update a NULL value into a column of this domain type will fail, even if the column definition does not specify NOT NULL.
+
+```sql
+CREATE DOMAIN required_text AS text NOT NULL;
+
+CREATE TABLE contacts (
+    id INTEGER PRIMARY KEY,
+    name required_text
+) STRICT;
+
+INSERT INTO contacts VALUES (1, 'Alice');
+-- OK
+
+INSERT INTO contacts VALUES (2, NULL);
+-- Error: domain required_text does not allow null values
+```
+
+A column-level NULL declaration does not override the domain's NOT NULL constraint.
+
+### CHECK
+
+Adds a validation constraint. The expression can reference `value` to refer to the input value being checked. Multiple CHECK constraints can be specified and all must pass.
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+
+CREATE TABLE measurements (
+    id INTEGER PRIMARY KEY,
+    reading positive_int
+) STRICT;
+
+INSERT INTO measurements VALUES (1, 42);
+-- OK
+
+INSERT INTO measurements VALUES (2, -5);
+-- Error: domain positive_int constraint violation
+```
+
+### CONSTRAINT name CHECK
+
+CHECK constraints can optionally be given a name for documentation purposes.
+
+```sql
+CREATE DOMAIN valid_score AS integer
+    CONSTRAINT non_negative CHECK (value >= 0)
+    CONSTRAINT max_hundred CHECK (value <= 100);
+```
+
+## Domain Chaining
+
+A domain can use another domain as its base type. When domains are chained, all constraints in the chain are enforced from child to ancestor.
+
+```sql
+CREATE DOMAIN base_amount AS integer CHECK (value > 0);
+CREATE DOMAIN small_amount AS base_amount CHECK (value < 1000);
+
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    quantity small_amount
+) STRICT;
+
+INSERT INTO orders VALUES (1, 50);
+-- OK: passes both value > 0 and value < 1000
+
+INSERT INTO orders VALUES (2, -1);
+-- Error: fails base_amount's CHECK (value > 0)
+
+INSERT INTO orders VALUES (3, 5000);
+-- Error: fails small_amount's CHECK (value < 1000)
+```
+
+Three or more levels of chaining are supported:
+
+```sql
+CREATE DOMAIN text_val AS text;
+CREATE DOMAIN nonempty AS text_val CHECK (length(value) > 0);
+CREATE DOMAIN short_text AS nonempty CHECK (length(value) < 50);
+
+CREATE TABLE labels (
+    id INTEGER PRIMARY KEY,
+    name short_text
+) STRICT;
+
+INSERT INTO labels VALUES (1, 'OK');
+-- OK
+
+INSERT INTO labels VALUES (2, '');
+-- Error: fails nonempty's CHECK (length(value) > 0)
+```
+
+## UPDATE Enforcement
+
+Domain constraints are enforced on UPDATE as well as INSERT.
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+
+CREATE TABLE items (
+    id INTEGER PRIMARY KEY,
+    stock positive_int
+) STRICT;
+
+INSERT INTO items VALUES (1, 10);
+UPDATE items SET stock = 20 WHERE id = 1;
+SELECT stock FROM items;
+-- 20
+
+UPDATE items SET stock = -1 WHERE id = 1;
+-- Error: domain positive_int constraint violation
+```
+
+## CAST Support
+
+CAST applies the domain's validation constraints:
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+
+SELECT CAST(42 AS positive_int);
+-- 42
+
+SELECT CAST(-1 AS positive_int);
+-- Error: domain positive_int constraint violation
+```
+
+Casting NULL to a NOT NULL domain is rejected:
+
+```sql
+CREATE DOMAIN notnull_int AS integer NOT NULL;
+
+SELECT CAST(NULL AS notnull_int);
+-- Error: domain notnull_int does not allow null values
+```
+
+## CHECK Constraints with Table-Level Checks
+
+Domain CHECK constraints and table-level CHECK constraints both apply. The domain constraint is checked during encoding and the table CHECK is checked separately.
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+
+CREATE TABLE bounded (
+    id INTEGER PRIMARY KEY,
+    val positive_int CHECK (val < 100)
+) STRICT;
+
+INSERT INTO bounded VALUES (1, 50);
+-- OK: passes domain CHECK (> 0) and table CHECK (< 100)
+
+INSERT INTO bounded VALUES (2, -1);
+-- Error: fails domain CHECK
+
+INSERT INTO bounded VALUES (3, 200);
+-- Error: fails table CHECK
+```
+
+## Operations on Domain Columns
+
+Domain columns support the same operations as their base type: arithmetic, comparisons, ordering, and aggregation.
+
+```sql
+CREATE DOMAIN myint AS integer;
+
+CREATE TABLE data (
+    id INTEGER PRIMARY KEY,
+    a myint,
+    b myint
+) STRICT;
+
+INSERT INTO data VALUES (1, 10, 3);
+SELECT a + b, a - b, a * b FROM data;
+-- 13|7|30
+```
+
+```sql
+CREATE DOMAIN myint AS integer;
+
+CREATE TABLE scores (
+    id INTEGER PRIMARY KEY,
+    val myint
+) STRICT;
+
+INSERT INTO scores VALUES (1, 30);
+INSERT INTO scores VALUES (2, 10);
+INSERT INTO scores VALUES (3, 20);
+SELECT val FROM scores ORDER BY val;
+-- 10
+-- 20
+-- 30
+```
+
+## Dropping Domains
+
+Domains are dropped with [DROP DOMAIN](/sql-reference/statements/drop-domain), not DROP TYPE. Attempting to use DROP TYPE on a domain (or DROP DOMAIN on a type) results in an error.
+
+A domain cannot be dropped while any table column or another domain references it.
+
+```sql
+CREATE DOMAIN my_domain AS integer;
+CREATE TABLE t(x my_domain) STRICT;
+
+DROP DOMAIN my_domain;
+-- Error: type 'my_domain' is in use
+
+DROP TABLE t;
+DROP DOMAIN my_domain;
+-- OK
+```
+
+## Restrictions
+
+- **STRICT tables only**: Using a domain type on a non-STRICT table is rejected at CREATE TABLE and ALTER TABLE ADD COLUMN time. Non-STRICT tables allow arbitrary type names as affinity hints, but domain constraints (CHECK, NOT NULL, DEFAULT) are only enforced on STRICT tables, so permitting them would be misleading.
+- **Cannot drop while in use**: A domain cannot be dropped while any table column or another domain references it.
+
+<Note>
+If a non-STRICT table was created with a type name that did not exist at the time (e.g., `CREATE TABLE t(x mydom)`), and a domain with that name is created afterwards (`CREATE DOMAIN mydom AS ...`), the domain constraints will **not** be retroactively enforced on the existing table. This is not a bug: non-STRICT tables treat all type names as plain affinity hints regardless of whether a matching domain exists. STRICT tables prevent this scenario because they reject unknown type names at CREATE TABLE time.
+</Note>
+- **No UNIQUE, PRIMARY KEY, or REFERENCES**: These constraints are not supported in domain definitions. Use table-level constraints instead.
+- **No duplicate clauses**: Multiple DEFAULT or NOT NULL clauses in the same definition are rejected. Conflicting NULL and NOT NULL clauses are also rejected.
+
+## See Also
+
+- [DROP DOMAIN](/sql-reference/statements/drop-domain) for removing domains
+- [CREATE TYPE](/sql-reference/statements/create-type) for defining custom types with ENCODE/DECODE logic
+- [Data Types](/sql-reference/data-types) for an overview of the type system
+- [CREATE TABLE](/sql-reference/statements/create-table) for STRICT table definitions

--- a/sql-reference/statements/create-table.mdx
+++ b/sql-reference/statements/create-table.mdx
@@ -323,7 +323,7 @@ CREATE TABLE bad (
 ```
 
 <Info>
-**Turso Extension**: STRICT tables also support custom types defined with [CREATE TYPE](/sql-reference/statements/create-type). Custom types extend the type system with user-defined encoding, decoding, validation, and operator overloading. See [Data Types](/sql-reference/data-types#custom-types) for details.
+**Turso Extension**: STRICT tables also support custom types defined with [CREATE TYPE](/sql-reference/statements/create-type) and [array types](/sql-reference/data-types#array-types). Custom types extend the type system with user-defined encoding, decoding, validation, and operator overloading. Array columns are declared by appending `[]` to a base type.
 </Info>
 
 ```sql
@@ -331,7 +331,8 @@ CREATE TABLE events (
     id uuid PRIMARY KEY,
     name varchar(100) NOT NULL,
     event_date date,
-    is_active boolean DEFAULT 1
+    is_active boolean DEFAULT 1,
+    tags TEXT[]
 ) STRICT;
 ```
 

--- a/sql-reference/statements/create-type.mdx
+++ b/sql-reference/statements/create-type.mdx
@@ -279,11 +279,239 @@ Turso provides the following built-in custom types in STRICT tables:
 The `uuid`, `json`, and `jsonb` types require their respective extensions to be compiled in. They are available by default in standard Turso builds.
 </Info>
 
+## Composite Types: STRUCT and UNION
+
+In addition to encode/decode custom types, CREATE TYPE supports two composite type forms: **STRUCT** (named product type) and **UNION** (discriminated union / tagged variant). Both store data as blobs on disk and require STRICT tables.
+
+### STRUCT
+
+A STRUCT groups multiple named fields into a single column. Use dot notation to read and filter on individual fields:
+
+```sql
+CREATE TYPE point AS STRUCT(x INT, y INT);
+
+CREATE TABLE locations (
+    id INTEGER PRIMARY KEY,
+    pos point
+) STRICT;
+
+INSERT INTO locations VALUES (1, struct_pack(10, 20));
+INSERT INTO locations VALUES (2, struct_pack(30, 40));
+
+-- Read fields with dot notation
+SELECT pos.x, pos.y FROM locations WHERE id = 1;
+-- 10|20
+
+-- Filter and order by fields
+SELECT id, pos.x FROM locations WHERE pos.y > 25 ORDER BY pos.x;
+-- 2|30
+```
+
+Dot notation works everywhere a column expression does — SELECT, WHERE, ORDER BY, GROUP BY, HAVING, and aggregate functions:
+
+```sql
+CREATE TYPE address AS STRUCT(street TEXT, city TEXT, zip TEXT);
+CREATE TABLE people(name TEXT, home address) STRICT;
+
+INSERT INTO people VALUES ('Alice', struct_pack('123 Main St', 'Springfield', '62704'));
+INSERT INTO people VALUES ('Bob', struct_pack('456 Oak Ave', 'Springfield', '62701'));
+
+SELECT home.city, COUNT(*) FROM people GROUP BY home.city;
+-- Springfield|2
+```
+
+When a table name and column name collide, table references always win. Use an alias to reach the struct field:
+
+```sql
+-- t.x here is table.column, not column.field
+SELECT t.x FROM t;
+
+-- Use an alias to access the struct field
+SELECT s.pos.x FROM locations AS s;
+```
+
+#### struct_pack()
+
+Creates a struct value for INSERT and UPDATE. Arguments are positional, matching the field order in the type definition.
+
+```sql
+INSERT INTO locations VALUES (1, struct_pack(10, 20));
+UPDATE locations SET pos = struct_pack(99, 88) WHERE id = 1;
+```
+
+#### struct_extract()
+
+Function form of dot notation — `struct_extract(col, 'field')` is equivalent to `col.field`. Primarily useful in expression indexes, where dot notation cannot be used:
+
+```sql
+CREATE INDEX idx_x ON locations(struct_extract(pos, 'x'));
+```
+
+### UNION
+
+A UNION is a discriminated union (tagged variant). Each value carries exactly one of the declared variants, identified by a tag. Use dot notation to extract a variant's value — it returns NULL when the active variant doesn't match:
+
+```sql
+CREATE TYPE platform_id AS UNION(telegram INT, slack TEXT, signal TEXT);
+
+CREATE TABLE contacts (
+    id INTEGER PRIMARY KEY,
+    platform platform_id
+) STRICT;
+
+INSERT INTO contacts VALUES (1, union_value('telegram', 12345));
+INSERT INTO contacts VALUES (2, union_value('slack', 'U0ABC'));
+INSERT INTO contacts VALUES (3, union_value('signal', '+1555'));
+
+-- Dot notation extracts the variant value (NULL if tag doesn't match)
+SELECT id, platform.telegram, platform.slack FROM contacts ORDER BY id;
+-- 1|12345|
+-- 2||U0ABC
+-- 3||
+
+-- Combine with union_tag() to filter by variant
+SELECT id, platform.slack FROM contacts WHERE union_tag(platform) = 'slack';
+-- 2|U0ABC
+```
+
+For unions whose variants are struct types, chain dot access to reach nested fields:
+
+```sql
+CREATE TYPE telegram_msg AS STRUCT(chat_id INT, text TEXT);
+CREATE TYPE msg AS UNION(telegram telegram_msg, slack TEXT);
+CREATE TABLE messages(id INT, data msg) STRICT;
+
+INSERT INTO messages VALUES (1, union_value('telegram', struct_pack(100, 'hello')));
+
+-- col.variant.field
+SELECT data.telegram.chat_id, data.telegram.text FROM messages;
+-- 100|hello
+```
+
+#### union_value()
+
+Creates a union value for INSERT and UPDATE. The first argument is the variant tag (a string literal), the second is the value. The tag is resolved against the target column's union type.
+
+```sql
+INSERT INTO contacts VALUES (1, union_value('telegram', 12345));
+UPDATE contacts SET platform = union_value('slack', 'U0XYZ') WHERE id = 1;
+```
+
+#### union_tag()
+
+Returns the tag name of the active variant as text.
+
+```sql
+SELECT id, union_tag(platform) FROM contacts ORDER BY id;
+-- 1|telegram
+-- 2|slack
+-- 3|signal
+```
+
+#### union_extract()
+
+Function form of dot notation — `union_extract(col, 'variant')` is equivalent to `col.variant`. Primarily useful in expression indexes:
+
+```sql
+CREATE INDEX idx_tg ON contacts(union_extract(platform, 'telegram'));
+```
+
+### NULL handling
+
+NULL values propagate through all struct and union operations:
+
+```sql
+CREATE TYPE number AS UNION(i INT, f REAL);
+CREATE TABLE values_t(id INT, val number) STRICT;
+
+INSERT INTO values_t VALUES (1, union_value('i', 42));
+INSERT INTO values_t VALUES (2, union_value('f', 3.14));
+INSERT INTO values_t VALUES (3, NULL);
+
+SELECT id, val.i, val.f FROM values_t ORDER BY id;
+-- 1|42|
+-- 2||3.14
+-- 3||
+```
+
+### Dot notation precedence
+
+When a dot expression `a.b` is ambiguous (e.g., `a` could be a table name or a column name), table references always take priority over struct field access. This follows DuckDB's resolution rules.
+
+```sql
+CREATE TYPE point AS STRUCT(x INT, y INT);
+CREATE TABLE t(x INT, t point) STRICT;
+INSERT INTO t VALUES (99, struct_pack(10, 20));
+
+-- t.x resolves as table.column (99), not column.field (10)
+SELECT t.x FROM t;
+-- 99
+
+-- Use an alias to reach the struct field
+SELECT s.t.x FROM t AS s;
+-- 10
+```
+
+For `a.b.c`, the resolution order is: database.table.column, then table.column.field.
+
+### Inline types not supported
+
+Inline STRUCT/UNION declarations in column definitions are not supported. Always use CREATE TYPE first:
+
+```sql
+-- This will error:
+CREATE TABLE t(data STRUCT(x INT, y INT)) STRICT;
+
+-- Do this instead:
+CREATE TYPE point AS STRUCT(x INT, y INT);
+CREATE TABLE t(data point) STRICT;
+```
+
+## Array Types
+
+Array columns store ordered collections of values. Unlike STRUCT and UNION, arrays don't require an explicit CREATE TYPE — declare them by appending `[]` to any base type name in a STRICT table column definition:
+
+```sql
+CREATE TABLE sensors (
+    id INTEGER PRIMARY KEY,
+    readings REAL[],
+    labels TEXT[],
+    flags INTEGER[]
+) STRICT;
+
+INSERT INTO sensors VALUES (1, ARRAY[1.5, 2.5, 3.5], ARRAY['temp','humidity'], '[0, 1, 1]');
+
+SELECT readings[0], labels[1], array_length(flags) FROM sensors;
+-- 1.5|humidity|3
+```
+
+Multi-dimensional arrays use multiple bracket pairs:
+
+```sql
+CREATE TABLE matrices (
+    id INTEGER PRIMARY KEY,
+    data INTEGER[][]
+) STRICT;
+
+INSERT INTO matrices VALUES (1, ARRAY[ARRAY[1,2], ARRAY[3,4]]);
+SELECT data[1][0] FROM matrices;
+-- 3
+```
+
+Element types are validated on insert — an `INTEGER[]` column rejects values that cannot be stored as integers. Arrays are stored internally as compact record-format BLOBs and displayed as JSON arrays on output.
+
+For the full set of array functions (`array_agg`, `array_append`, `array_contains`, `array_slice`, etc.), operators (`@>`, `&&`, `||`), and subscript syntax, see [Array Functions](/sql-reference/functions/array).
+
 ## Restrictions
 
 - **STRICT tables only**: Custom type names are ignored in non-STRICT tables. The column uses standard type affinity rules instead.
 - **Cannot drop while in use**: A type cannot be dropped with DROP TYPE while any table has a column of that type.
+
+<Note>
+If a non-STRICT table was created with a type name that did not exist at the time (e.g., `CREATE TABLE t(x mytype)`), and a custom type with that name is created afterwards (`CREATE TYPE mytype ...`), the type's ENCODE/DECODE logic will **not** be retroactively applied to the existing table. This is not a bug: non-STRICT tables treat all type names as plain affinity hints regardless of whether a matching custom type exists. STRICT tables prevent this scenario because they reject unknown type names at CREATE TABLE time.
+</Note>
 - **No subqueries in expressions**: The ENCODE, DECODE, and DEFAULT expressions cannot contain subqueries, aggregate functions, or window functions.
+- **No indexes on STRUCT/UNION columns**: CREATE INDEX on a STRUCT or UNION column is not supported.
 
 ## Examples
 
@@ -385,5 +613,8 @@ SELECT amount + tax FROM transactions;
 ## See Also
 
 - [DROP TYPE](/sql-reference/statements/drop-type) for removing custom types
+- [CREATE DOMAIN](/sql-reference/statements/create-domain) for defining constrained type aliases without ENCODE/DECODE logic
 - [Data Types](/sql-reference/data-types) for an overview of the type system and type affinity
+- [Array Types](/sql-reference/data-types#array-types) for native array columns (`INTEGER[]`, `TEXT[]`, etc.)
+- [Array Functions](/sql-reference/functions/array) for array construction, manipulation, and operators
 - [CREATE TABLE](/sql-reference/statements/create-table) for STRICT table definitions

--- a/sql-reference/statements/drop-domain.mdx
+++ b/sql-reference/statements/drop-domain.mdx
@@ -1,0 +1,95 @@
+---
+title: DROP DOMAIN
+description: Remove a user-defined domain from the database
+sidebarTitle: DROP DOMAIN
+---
+
+# DROP DOMAIN
+
+<Info>
+**Turso Extension**: DROP DOMAIN is a Turso-specific statement not available in standard SQLite. This feature is experimental and must be [enabled before use](/sql-reference/experimental-features).
+</Info>
+
+The DROP DOMAIN statement removes a user-defined domain from the database. Once dropped, the domain name can no longer be used in new column definitions.
+
+## Syntax
+
+```sql
+DROP DOMAIN [IF EXISTS] domain-name;
+```
+
+## Description
+
+DROP DOMAIN removes the named domain from the database. The domain must exist unless the `IF EXISTS` clause is specified.
+
+### Clauses
+
+| Clause | Description |
+|--------|-------------|
+| `IF EXISTS` | Suppresses the error that would occur if the domain does not exist. The statement is a no-op when the domain is not found. |
+| `domain-name` | The name of the domain to remove. |
+
+### Restrictions
+
+A domain cannot be dropped while any table column uses it or while another domain references it as a base type. Remove all dependents before dropping.
+
+```sql
+CREATE DOMAIN base_d AS integer;
+CREATE DOMAIN child_d AS base_d CHECK (value > 0);
+
+-- Fails: child_d depends on base_d
+DROP DOMAIN base_d;
+
+-- Drop child first, then base
+DROP DOMAIN child_d;
+DROP DOMAIN base_d;
+```
+
+### DROP DOMAIN vs DROP TYPE
+
+DROP DOMAIN can only remove domains created with CREATE DOMAIN. Attempting to use DROP DOMAIN on a type created with CREATE TYPE results in an error, and vice versa.
+
+```sql
+CREATE TYPE my_type BASE integer ENCODE value DECODE value;
+DROP DOMAIN my_type;
+-- Error: 'my_type' is a type, not a domain. Use DROP TYPE instead
+
+CREATE DOMAIN my_domain AS integer;
+DROP TYPE my_domain;
+-- Error: 'my_domain' is a domain, not a type. Use DROP DOMAIN instead
+```
+
+## Examples
+
+### Drop a Domain
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+DROP DOMAIN positive_int;
+```
+
+### Drop with IF EXISTS
+
+```sql
+-- Safe to run even if the domain does not exist
+DROP DOMAIN IF EXISTS nonexistent_domain;
+```
+
+### Drop After Removing Table Dependency
+
+```sql
+CREATE DOMAIN score AS integer CHECK (value >= 0);
+CREATE TABLE results (id INTEGER PRIMARY KEY, val score) STRICT;
+
+-- Fails: table 'results' uses domain 'score'
+-- DROP DOMAIN score;
+
+DROP TABLE results;
+DROP DOMAIN score;
+-- OK
+```
+
+## See Also
+
+- [CREATE DOMAIN](/sql-reference/statements/create-domain) for defining domains
+- [DROP TYPE](/sql-reference/statements/drop-type) for removing custom types

--- a/sql-reference/statements/drop-type.mdx
+++ b/sql-reference/statements/drop-type.mdx
@@ -72,4 +72,5 @@ DROP TYPE IF EXISTS reversed_text;
 ## See Also
 
 - [CREATE TYPE](/sql-reference/statements/create-type) for defining custom types
+- [DROP DOMAIN](/sql-reference/statements/drop-domain) for removing domains
 - [Data Types](/sql-reference/data-types) for an overview of the type system

--- a/sql-reference/statements/insert.mdx
+++ b/sql-reference/statements/insert.mdx
@@ -31,7 +31,7 @@ INSERT [OR conflict_action] INTO table_name [(column_name [, ...])]
 | `conflict_action` | keyword | One of REPLACE, IGNORE, ABORT, ROLLBACK, or FAIL. Controls behavior on constraint violations |
 | `table_name` | identifier | The table to insert rows into |
 | `column_name` | identifier | Column to assign a value to. Unlisted columns receive their default value or NULL |
-| `expression` | expression | A value to insert. Must match the position or name of the target column |
+| `expression` | expression | A value to insert, or the keyword `DEFAULT` to use the column's default value. Must match the position or name of the target column |
 | `select_statement` | SELECT query | A query whose result rows are inserted into the table |
 | `result_column` | expression | Column or expression to return for each inserted row |
 
@@ -125,6 +125,37 @@ CREATE TABLE tasks (
 -- status, priority, and created_at use their defaults
 INSERT INTO tasks (title) VALUES ('Review pull request');
 ```
+
+## DEFAULT Keyword in VALUES
+
+<Info>
+**Turso extension** -- This feature follows the SQL standard (SQL:2016) but is not supported by SQLite.
+</Info>
+
+The `DEFAULT` keyword can be used in place of any value expression in a VALUES list. It resolves to the column's default value as defined in the CREATE TABLE statement, or NULL if no default is defined. This is particularly useful when inserting multiple rows where different rows need defaults for different columns -- something that cannot be achieved by simply omitting columns from the column list.
+
+```sql
+CREATE TABLE tasks (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  status TEXT DEFAULT 'pending',
+  priority INTEGER DEFAULT 0
+);
+
+-- Use DEFAULT for specific columns
+INSERT INTO tasks (id, title, status, priority)
+VALUES (1, 'Fix bug', DEFAULT, 5);
+-- Inserts: (1, 'Fix bug', 'pending', 5)
+
+-- Different columns use DEFAULT in different rows
+INSERT INTO tasks (id, title, status, priority) VALUES
+  (2, 'Write docs', DEFAULT, 3),
+  (3, 'Code review', 'in_progress', DEFAULT);
+-- Inserts: (2, 'Write docs', 'pending', 3)
+--          (3, 'Code review', 'in_progress', 0)
+```
+
+The `DEFAULT` keyword is only valid inside INSERT VALUES lists. Using it in other contexts (SELECT, WHERE, UPDATE) produces an error.
 
 ## Conflict Handling
 

--- a/sql-reference/statements/vacuum.mdx
+++ b/sql-reference/statements/vacuum.mdx
@@ -1,0 +1,166 @@
+---
+title: VACUUM
+description: Rebuild the database file to reclaim unused space and defragment storage
+sidebarTitle: VACUUM
+---
+
+# VACUUM
+
+The VACUUM statement rebuilds the database file to reclaim unused space, defragment tables and indexes, and reduce the file size. Two forms are supported: `VACUUM` rebuilds the current database in place, while `VACUUM INTO` writes a compacted copy to a new file without modifying the source.
+
+## Syntax
+
+```sql
+VACUUM [schema-name];
+VACUUM [schema-name] INTO filename;
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `schema-name` | The database to vacuum. For in-place `VACUUM` only `main` is supported. For `VACUUM INTO` any attached schema is accepted; `temp` is a no-op and produces no file. Defaults to `main`. |
+| `filename` | A string literal giving the destination file path for `VACUUM INTO`. Bind parameters are not accepted. |
+
+## Common Requirements
+
+These rules apply to both `VACUUM` and `VACUUM INTO`:
+
+- The connection must be in autocommit mode — neither form can run inside an explicit `BEGIN` transaction.
+- No other statement may be active on the same connection.
+- The connection must not be in `query_only` mode.
+- The source database must not have `auto_vacuum = incremental`. Incremental autovacuum is not supported.
+
+## VACUUM
+
+<Info>
+In-place `VACUUM` is experimental and must be [enabled before use](/sql-reference/experimental-features). `VACUUM INTO` does not require the flag and is always available.
+</Info>
+
+In-place `VACUUM` rebuilds the main database by writing a compacted image into an internal temp database and then copying those pages back over the original file. When it completes, unused pages have been released and all storage-backed objects have been recreated.
+
+### Effect
+
+- Unused pages from deleted rows and dropped objects are removed, shrinking the file.
+- All storage-backed tables are recreated and their rows reinserted, which rebuilds the associated indexes.
+- `sqlite_sequence` counters used by `AUTOINCREMENT` columns are preserved.
+- The schema cookie is bumped so that other connections reload their cached schema on their next access.
+- The page size, reserved space, text encoding, user version, and application ID are preserved exactly.
+
+### Requirements
+
+In addition to the [common requirements](#common-requirements):
+
+- The database must be opened in WAL journal mode.
+- The database must not be in-memory.
+- The database must not be read-only.
+- Only the `main` database is supported. Vacuuming an attached schema in place is not supported yet.
+- No other process may currently hold the multi-process WAL.
+
+### MVCC Databases
+
+When the database uses MVCC (`PRAGMA journal_mode = mvcc`), additional rules apply to in-place `VACUUM`:
+
+- All MVCC changes must be checkpointed first. If the MVCC log contains uncheckpointed changes, `VACUUM` returns an error — run `PRAGMA wal_checkpoint(TRUNCATE)` first.
+- No other MVCC transaction may be active on any connection. `VACUUM` returns a busy error if one is found.
+- During the operation the MVCC subsystem is paused so that the rebuilt schema and log can be reconciled atomically.
+
+## VACUUM INTO
+
+`VACUUM INTO` builds a compacted copy of the database at the given path and leaves the source database untouched. The destination is a fully self-contained database file that can be opened independently.
+
+### Effect
+
+- A new database file is created at `filename` containing all user tables, indexes, triggers, views, and virtual table content from the source.
+- Indexes, triggers, and views are recreated after the data is copied so that triggers do not fire during the copy.
+- Custom index methods (for example FTS and vector) rebuild their backing structures from the copied data.
+- `sqlite_sequence` counters used by `AUTOINCREMENT` columns are preserved.
+- Page size, reserved space, text encoding, user version, and application ID are copied from the source.
+- If the source uses MVCC, the destination is created with MVCC enabled but with fresh state. The source's MVCC metadata table is not copied across.
+- The file is fully synced and a TRUNCATE checkpoint is performed before the statement returns, so the destination is durable without further action.
+
+<Warning>
+`VACUUM INTO` does not carry encryption through to the destination. Even when the source is encrypted, the compacted copy is written as an ordinary unencrypted database file and can be opened without a key. Reserved header bytes are still copied across, so the destination's page layout matches the source.
+</Warning>
+
+### Requirements
+
+In addition to the [common requirements](#common-requirements):
+
+- The destination file must not already exist. Delete or move it first if you want to overwrite.
+- The path must be provided as a string literal in the SQL statement.
+- `VACUUM temp INTO filename` is a no-op and does not create a file, matching SQLite's behavior.
+
+`VACUUM INTO` takes a consistent view of the source by starting an implicit read transaction for the duration of the copy, so the destination always reflects a single snapshot of the source even if other connections write to it during the copy.
+
+## Examples
+
+### Rebuild the Main Database
+
+```sql
+-- Reclaim space and defragment the current database
+VACUUM;
+```
+
+### Write a Compacted Copy to a New File
+
+```sql
+VACUUM INTO 'backup.db';
+```
+
+The source database is unchanged. `backup.db` can be opened as a standalone database:
+
+```bash
+tursodb backup.db
+```
+
+### Vacuum an Attached Database Into a New File
+
+```sql
+ATTACH DATABASE 'archive.db' AS archive;
+
+-- Write a compacted copy of the archive schema to a new file
+VACUUM archive INTO 'archive-compact.db';
+```
+
+### Use VACUUM INTO for a Backup Snapshot
+
+Because `VACUUM INTO` copies from a consistent snapshot, it is a simple way to capture a point-in-time backup of an active database:
+
+```sql
+VACUUM INTO '/var/backups/app-2026-04-23.db';
+```
+
+### Restore Performance After Heavy Churn
+
+After bulk deletes or long-running workloads that leave indexes fragmented, `VACUUM` rebuilds the indexes and often improves scan speed:
+
+```sql
+DELETE FROM events WHERE created_at < '2025-01-01';
+VACUUM;
+```
+
+## Errors
+
+| Error | Cause |
+|-------|-------|
+| `VACUUM is an experimental feature. Enable with --experimental-vacuum flag` | In-place `VACUUM` used in a release build without the experimental flag. |
+| `VACUUM is only supported for the main database; schema '<name>' is not supported yet` | In-place `VACUUM schema-name` with a schema other than `main`. |
+| `Cannot execute VACUUM in query_only mode` | `VACUUM` or `VACUUM INTO` run on a connection where `PRAGMA query_only` is set. |
+| `cannot VACUUM from within a transaction` / `cannot VACUUM INTO from within a transaction` | Run inside an explicit `BEGIN`. |
+| `cannot VACUUM - SQL statements in progress` | Another statement is still active on the same connection. |
+| `Incremental auto-vacuum is not supported` | The source database has `auto_vacuum = incremental`. Applies to both `VACUUM` and `VACUUM INTO`. |
+| `VACUUM requires a WAL-mode database` | In-place `VACUUM` on a non-WAL database. |
+| `cannot VACUUM an in-memory database` | In-place `VACUUM` on an in-memory database. |
+| `ReadOnly` | In-place `VACUUM` on a read-only database. |
+| `cannot VACUUM while experimental multiprocess WAL is active in another process` | In-place `VACUUM` while another process holds the multi-process WAL. |
+| `cannot VACUUM an MVCC database with uncheckpointed changes; run PRAGMA wal_checkpoint(TRUNCATE) first` | In-place `VACUUM` on an MVCC database with pending log entries. |
+| `output file already exists: <path>` | The destination for `VACUUM INTO` already exists. |
+| `VACUUM INTO path cannot be empty` | `VACUUM INTO ''` was used. |
+| `VACUUM INTO requires a string literal path` | A non-literal expression (for example a bind parameter) was used for the destination. |
+| `no such database: <name>` | `VACUUM <schema> INTO` referenced an unknown schema. |
+
+## See Also
+
+- [Experimental Features](/sql-reference/experimental-features) for enabling in-place `VACUUM`
+- [PRAGMAs](/sql-reference/pragmas) for `auto_vacuum`, `journal_mode`, `query_only`, and `wal_checkpoint`
+- [ATTACH DATABASE](/sql-reference/statements/attach-database) for attaching a schema that can be targeted by `VACUUM INTO`
+- [ANALYZE](/sql-reference/statements/analyze) for refreshing query planner statistics after a vacuum


### PR DESCRIPTION
## Summary
- Updates `turso` submodule to latest `origin/main` (63 commits)
- Extends `scripts/sync-sql-reference.py` to support CLI subdirectory as a separate **CLI Reference** navigation group (placed before SQL Reference)
- Adds new SQL statement docs: `CREATE DOMAIN`, `DROP DOMAIN`, `VACUUM`
- Adds new function doc: `array`
- Adds new top-level doc: `multiprocess-access`
- Syncs all updated `.mdx` content (data-types, expressions, aggregate functions, etc.)

## Test plan
- [x] Ran `python3 scripts/sync-sql-reference.py` — copied 46 files, updated `docs.json`
- [x] Verified `docs.json` has separate "CLI Reference" and "SQL Reference" groups
- [x] Verified all new files exist under `sql-reference/`
- [x] Local `mintlify dev` preview renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)