### PR TITLE
Reframe libSQL SDK & Embedded Replicas docs: production-ready, not legacy

### DIFF
--- a/features/embedded-replicas/introduction.mdx
+++ b/features/embedded-replicas/introduction.mdx
@@ -4,9 +4,9 @@ sidebarTitle: Introduction
 ---
 
 <Info>
-  Embedded Replicas keep a local read replica of a Turso Cloud database: reads run locally from the file in microseconds, and writes are sent to the cloud primary and then reflected back to the replica. They are fully supported in production and remain a good fit for server and VM deployments where the cloud is the source of truth and you want low-latency reads.
+  Embedded Replicas keep a local read replica of a Turso Cloud database: reads run locally from the file in microseconds, and writes are sent to the cloud primary and then reflected back to the replica. Embedded Replicas are fully supported in production.
 
-  If your workload is **offline-first**, **multi-writer**, or needs **local writes that sync later** (the equivalent of `offline: true`), use [Turso Sync](/sync/usage). Sync is the newer engine built on Turso Database with logical change-data-capture and explicit `push()` / `pull()` — [significantly less bandwidth and lower latency](https://turso.tech/blog/sync-benchmark) than page-level replication for write-heavy or intermittently-connected clients.
+  For new projects that need sync, we recommend [Turso Sync](/sync/usage). Sync is built on the Turso Database engine and uses logical change-data-capture, providing local-first writes, explicit `push()` / `pull()`, and [significantly less bandwidth and lower latency](https://turso.tech/blog/sync-benchmark) than the page-level replication Embedded Replicas use.
 </Info>
 
 Turso Cloud's embedded replicas let you replicate a database right within your application. This is especially useful for VMs or VPS deployments, and for mobile applications where stable connectivity is a challenge, since they allow uninterrupted access to the local database.

--- a/features/embedded-replicas/introduction.mdx
+++ b/features/embedded-replicas/introduction.mdx
@@ -3,9 +3,11 @@ title: Embedded Replicas
 sidebarTitle: Introduction
 ---
 
-<Warning>
-  Embedded Replicas are a legacy Turso Cloud feature built on [libSQL](/libsql). **Writes are sent to the remote primary database, not stored locally.** For new projects that need sync, use [Turso Sync](/sync/usage), which is built on the Turso Database engine and provides true local-first reads and writes with explicit push/pull. For offline-first writes (the equivalent of `offline: true`), see [Offline-first writes](/sync/usage#offline-first-writes).
-</Warning>
+<Info>
+  Embedded Replicas keep a local read replica of a Turso Cloud database: reads run locally from the file in microseconds, and writes are sent to the cloud primary and then reflected back to the replica. They are fully supported in production and remain a good fit for server and VM deployments where the cloud is the source of truth and you want low-latency reads.
+
+  If your workload is **offline-first**, **multi-writer**, or needs **local writes that sync later** (the equivalent of `offline: true`), use [Turso Sync](/sync/usage). Sync is the newer engine built on Turso Database with logical change-data-capture and explicit `push()` / `pull()` — [significantly less bandwidth and lower latency](https://turso.tech/blog/sync-benchmark) than page-level replication for write-heavy or intermittently-connected clients.
+</Info>
 
 Turso Cloud's embedded replicas let you replicate a database right within your application. This is especially useful for VMs or VPS deployments, and for mobile applications where stable connectivity is a challenge, since they allow uninterrupted access to the local database.
 

--- a/sdk/go/quickstart.mdx
+++ b/sdk/go/quickstart.mdx
@@ -171,12 +171,14 @@ func main() {
   </Step>
 </Steps>
 
-## Legacy: go-libsql (Embedded Replicas)
+## Embedded Replicas (go-libsql)
 
-<Warning>
+<Info>
 
-**Usage of embedded replicas is strongly discouraged.** With embedded replicas, reads are local but **writes are sent to the remote database** — this means writes fail when offline, have higher latency, and don't support concurrent writes. Use `tursogo` with `NewTursoSyncDb` instead: all reads and writes are local, and you explicitly sync with `Push()` / `Pull()`.
+Embedded Replicas give your Go app a local read copy of a Turso Cloud database. Reads are served locally; writes go to the cloud primary and are reflected back to the replica. This model is fully supported in production and is a good fit for server and VM deployments that want low-latency reads with a single cloud source of truth.
 
-</Warning>
+For workloads that need **offline writes**, **bidirectional sync**, or **multi-writer convergence**, prefer `tursogo` with `NewTursoSyncDb`: both reads and writes are local, you sync explicitly with `Push()` / `Pull()`, and the wire format is logical change-data-capture rather than page frames ([benchmark](https://turso.tech/blog/sync-benchmark)).
 
-See the [reference](/sdk/go/reference) for legacy documentation on embedded replicas if you have an existing `go-libsql` codebase.
+</Info>
+
+See the [reference](/sdk/go/reference) for full documentation on Embedded Replicas with `go-libsql`.

--- a/sdk/go/quickstart.mdx
+++ b/sdk/go/quickstart.mdx
@@ -175,9 +175,9 @@ func main() {
 
 <Info>
 
-Embedded Replicas give your Go app a local read copy of a Turso Cloud database. Reads are served locally; writes go to the cloud primary and are reflected back to the replica. This model is fully supported in production and is a good fit for server and VM deployments that want low-latency reads with a single cloud source of truth.
+Embedded Replicas give your Go app a local read copy of a Turso Cloud database. Reads are served locally; writes go to the cloud primary and are reflected back to the replica. Embedded Replicas are fully supported in production.
 
-For workloads that need **offline writes**, **bidirectional sync**, or **multi-writer convergence**, prefer `tursogo` with `NewTursoSyncDb`: both reads and writes are local, you sync explicitly with `Push()` / `Pull()`, and the wire format is logical change-data-capture rather than page frames ([benchmark](https://turso.tech/blog/sync-benchmark)).
+For new projects that need sync, we recommend `tursogo` with `NewTursoSyncDb`: both reads and writes are local, you sync explicitly with `Push()` / `Pull()`, and the wire format is logical change-data-capture rather than page frames ([benchmark](https://turso.tech/blog/sync-benchmark)).
 
 </Info>
 

--- a/sdk/go/reference.mdx
+++ b/sdk/go/reference.mdx
@@ -7,7 +7,7 @@ Turso offers two Go packages:
 
 | | `tursogo` | `libsql-client-go` | `go-libsql` |
 | --- | --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Remote access (over-the-wire) | Embedded Replicas (cloud-replicated reads) |
+| **Use case** | Local / embedded database, sync | Remote access (over-the-wire) | Existing libSQL codebases |
 | **Engine** | Turso Database (rewrite) | libSQL wire protocol | libSQL (SQLite fork) |
 | **Concurrent writes** | Yes (MVCC) | N/A (remote) | Not supported |
 | **Sync** | push/pull (local-first) | — | Embedded Replicas (writes go to cloud primary) |
@@ -179,11 +179,11 @@ rows, err := db.Query("SELECT * FROM users WHERE id = ?", 1)
 
 ## go-libsql (libSQL)
 
-The `go-libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you need Embedded Replicas or are working with an existing `go-libsql`-based codebase.
+The `go-libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you are working with an existing `go-libsql`-based codebase.
 
 <Info>
 
-With `go-libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. This is fully supported and ideal when the cloud is your source of truth. If you need local-first writes (offline, multi-writer, or bidirectional sync), use `tursogo` with `NewTursoSyncDb` — see the [quickstart](/sdk/go/quickstart).
+With `go-libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. Embedded Replicas are fully supported. For new projects that need sync, we recommend `tursogo` with `NewTursoSyncDb` — see the [quickstart](/sdk/go/quickstart).
 
 </Info>
 

--- a/sdk/go/reference.mdx
+++ b/sdk/go/reference.mdx
@@ -5,12 +5,12 @@ description: Go Reference for Turso
 
 Turso offers two Go packages:
 
-| | `tursogo` | `libsql-client-go` | `go-libsql` (legacy) |
+| | `tursogo` | `libsql-client-go` | `go-libsql` |
 | --- | --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Remote access (over-the-wire) | Legacy — embedded replicas |
+| **Use case** | Local / embedded database, sync | Remote access (over-the-wire) | Embedded Replicas (cloud-replicated reads) |
 | **Engine** | Turso Database (rewrite) | libSQL wire protocol | libSQL (SQLite fork) |
 | **Concurrent writes** | Yes (MVCC) | N/A (remote) | Not supported |
-| **Sync** | push/pull (true local-first) | — | Embedded replicas (writes go to remote) |
+| **Sync** | push/pull (local-first) | — | Embedded Replicas (writes go to cloud primary) |
 | **CGO** | Not required | Not required | Required |
 | **API** | `database/sql` | `database/sql` | `database/sql` |
 
@@ -177,23 +177,23 @@ Uses the standard `database/sql` interface — same as `tursogo`:
 rows, err := db.Query("SELECT * FROM users WHERE id = ?", 1)
 ```
 
-## go-libsql (Legacy)
+## go-libsql (libSQL)
 
-The `go-libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. It is fully supported — if you run into something that doesn't work yet with `tursogo`, `go-libsql` is a reliable fallback.
+The `go-libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you need Embedded Replicas or are working with an existing `go-libsql`-based codebase.
 
 <Info>
 
-With `go-libsql` embedded replicas, reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use `tursogo` with `NewTursoSyncDb` — see the [quickstart](/sdk/go/quickstart).
+With `go-libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. This is fully supported and ideal when the cloud is your source of truth. If you need local-first writes (offline, multi-writer, or bidirectional sync), use `tursogo` with `NewTursoSyncDb` — see the [quickstart](/sdk/go/quickstart).
 
 </Info>
 
 ### Embedded Replicas
 
-<Warning>
+<Info>
 
-For new projects, we recommend `tursogo` with `NewTursoSyncDb` for sync use cases — it is built on the Turso Database engine with better performance, true local-first writes, and concurrent write support.
+For workloads that need **offline writes**, **bidirectional sync**, or **multi-writer convergence**, we recommend `tursogo` with `NewTursoSyncDb` — both reads and writes are local, and you sync explicitly with `Push()` / `Pull()`.
 
-</Warning>
+</Info>
 
 You can work with [embedded replicas](/features/embedded-replicas) that can sync from the remote database to a local SQLite file, and delegate writes to the remote primary database:
 

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -10,7 +10,7 @@ title: Turso SDKs
 | **Local database** (embedded, on-device, offline) | `@tursodatabase/database` | `pyturso` | `tursogo` | `turso` |
 | **Local database + cloud sync** (push/pull) | `@tursodatabase/sync` | `pyturso` (with sync) | `tursogo` (with sync) | `turso` (with `sync` feature) |
 | **Remote access** (servers, Docker, serverless, edge — any over-the-wire) | `@tursodatabase/serverless` | `libsql` | `libsql-client-go` | `libsql` (with `remote` feature) |
-| **Cloud-replicated (libSQL)** — Embedded Replicas, ORM support (Drizzle, Prisma), battle-tested | `@libsql/client` | `libsql` | `go-libsql` | `libsql` |
+| **libSQL** — ORM support (Drizzle, Prisma), production-ready, battle-tested | `@libsql/client` | `libsql` | `go-libsql` | `libsql` |
 
 **Starting a new project?** Use `@tursodatabase/database` (TypeScript), `pyturso` (Python), `tursogo` (Go), or `turso` (Rust). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and local-first sync.
 
@@ -27,7 +27,7 @@ title: Turso SDKs
 Keeping `@tursodatabase/database` and `@tursodatabase/serverless` separate means minimal bundle size. `@tursodatabase/serverless` uses only `fetch` — zero native dependencies, so it works in Node.js, Docker containers, serverless functions, edge runtimes, and browsers.
 
 <Info>
-  **Need sync?** The libSQL-based SDKs below support Embedded Replicas — reads are local and writes are sent to the cloud primary. If you need local writes as well (offline-first, multi-writer, or bidirectional sync), use [Turso Sync](/sync/usage).
+  **Need sync?** For new projects, use [Turso Sync](/sync/usage) — it gives you local reads and writes with explicit `push()` / `pull()` to the cloud. The libSQL-based SDKs below also support Embedded Replicas, where reads are local and writes are sent to the cloud primary.
 </Info>
 
 ## Official SDKs

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -10,9 +10,9 @@ title: Turso SDKs
 | **Local database** (embedded, on-device, offline) | `@tursodatabase/database` | `pyturso` | `tursogo` | `turso` |
 | **Local database + cloud sync** (push/pull) | `@tursodatabase/sync` | `pyturso` (with sync) | `tursogo` (with sync) | `turso` (with `sync` feature) |
 | **Remote access** (servers, Docker, serverless, edge — any over-the-wire) | `@tursodatabase/serverless` | `libsql` | `libsql-client-go` | `libsql` (with `remote` feature) |
-| **Legacy (libSQL)** — ORM support (Drizzle, Prisma), battle-tested | `@libsql/client` | `libsql` | `go-libsql` | `libsql` |
+| **Cloud-replicated (libSQL)** — Embedded Replicas, ORM support (Drizzle, Prisma), battle-tested | `@libsql/client` | `libsql` | `go-libsql` | `libsql` |
 
-**Starting a new project?** Use `@tursodatabase/database` (TypeScript), `pyturso` (Python), `tursogo` (Go), or `turso` (Rust). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and true local-first sync.
+**Starting a new project?** Use `@tursodatabase/database` (TypeScript), `pyturso` (Python), `tursogo` (Go), or `turso` (Rust). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and local-first sync.
 
 **Need sync?** Use [Turso Sync](/sync/usage) for local reads and writes with explicit `push()` / `pull()` to Turso Cloud.
 
@@ -20,14 +20,14 @@ title: Turso SDKs
 
 **Migrating from SQLite?** Turso Database is a drop-in replacement. Your existing SQL, schema, and queries work unchanged.
 
-**Already using `@libsql/client`, `libsql`, or `go-libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. They are fully supported and battle-tested. Consider migrating to the Turso Database packages for better sync support and concurrent writes — but if you run into something that doesn't work yet with the newer packages, the libSQL-based ones are reliable fallbacks.
+**Already using `@libsql/client`, `libsql`, or `go-libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. They are production-ready and battle-tested. If your workload needs concurrent writes, push/pull sync, or local-first writes (offline / multi-writer / bidirectional), the Turso Database packages are also a good choice — pick the one that fits your workload.
 
 ### Why multiple packages in TypeScript?
 
 Keeping `@tursodatabase/database` and `@tursodatabase/serverless` separate means minimal bundle size. `@tursodatabase/serverless` uses only `fetch` — zero native dependencies, so it works in Node.js, Docker containers, serverless functions, edge runtimes, and browsers.
 
 <Info>
-  **Need sync?** If you want local reads and writes with push/pull sync to the cloud, use [Turso Sync](/sync/usage). The SDKs below connect to Turso Cloud using libSQL, where embedded replica sync only replicates reads locally — writes go to the cloud.
+  **Need sync?** The libSQL-based SDKs below support Embedded Replicas — reads are local and writes are sent to the cloud primary. If you need local writes as well (offline-first, multi-writer, or bidirectional sync), use [Turso Sync](/sync/usage).
 </Info>
 
 ## Official SDKs

--- a/sdk/python/quickstart.mdx
+++ b/sdk/python/quickstart.mdx
@@ -140,8 +140,8 @@ print(rows)
   </Step>
 </Steps>
 
-## Legacy: libsql (Embedded Replicas)
+## Embedded Replicas (libsql)
 
-The `libsql` package also supports embedded replicas, where reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use `turso.sync` instead.
+The `libsql` package also supports Embedded Replicas — local reads from a file, with writes sent to the cloud primary and reflected back to the replica. Use this when the cloud is your source of truth and you want fast local reads. For local-first writes with push/pull sync, use `turso.sync` instead.
 
-See the [reference](/sdk/python/reference) for full documentation on embedded replicas, encryption, and periodic sync.
+See the [reference](/sdk/python/reference) for full documentation on Embedded Replicas, encryption, and periodic sync.

--- a/sdk/python/quickstart.mdx
+++ b/sdk/python/quickstart.mdx
@@ -142,6 +142,6 @@ print(rows)
 
 ## Embedded Replicas (libsql)
 
-The `libsql` package also supports Embedded Replicas — local reads from a file, with writes sent to the cloud primary and reflected back to the replica. Use this when the cloud is your source of truth and you want fast local reads. For local-first writes with push/pull sync, use `turso.sync` instead.
+The `libsql` package also supports Embedded Replicas — local reads from a file, with writes sent to the cloud primary and reflected back to the replica. Embedded Replicas are fully supported in production. For new projects that need sync, we recommend `turso.sync` instead: both reads and writes are local, and you sync explicitly with `push()` / `pull()`.
 
 See the [reference](/sdk/python/reference) for full documentation on Embedded Replicas, encryption, and periodic sync.

--- a/sdk/python/reference.mdx
+++ b/sdk/python/reference.mdx
@@ -5,15 +5,15 @@ description: Python Reference for Turso
 
 Turso offers two Python packages:
 
-| | `pyturso` | `libsql` (legacy) |
+| | `pyturso` | `libsql` |
 | --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Legacy — embedded replicas |
+| **Use case** | Local / embedded database, sync | Embedded Replicas (cloud-replicated reads) |
 | **Engine** | Turso Database (rewrite) | libSQL (SQLite fork) |
 | **Concurrent writes** | Yes (MVCC) | Not supported |
-| **Sync** | push/pull (true local-first) | Embedded replicas (writes go to remote) |
+| **Sync** | push/pull (local-first) | Embedded Replicas (writes go to cloud primary) |
 | **API** | Python `sqlite3`-compatible | Python `sqlite3`-compatible |
 
-**Starting a new project?** Use `pyturso` — it is built on the Turso Database engine with better performance, concurrent writes, and true local-first sync.
+**Starting a new project?** Use `pyturso` — it is built on the Turso Database engine with concurrent writes and local-first sync.
 
 ## pyturso
 
@@ -73,23 +73,23 @@ Turso Cloud databases can also be encrypted with bring-your-own-key — [learn m
 
 </Info>
 
-## libsql (Legacy)
+## libsql (libSQL)
 
-The `libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. It is fully supported — if you run into something that doesn't work yet with `pyturso`, `libsql` is a reliable fallback.
+The `libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you need Embedded Replicas or are working with an existing `libsql`-based codebase.
 
 <Info>
 
-With `libsql` embedded replicas, reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use `turso.sync` — see the [quickstart](/sdk/python/quickstart).
+With `libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. This is fully supported and ideal when the cloud is your source of truth. If you need local-first writes (offline, multi-writer, or bidirectional sync), use `turso.sync` — see the [quickstart](/sdk/python/quickstart).
 
 </Info>
 
 ## Embedded Replicas
 
-<Warning>
+<Info>
 
-For new projects, we recommend `turso.sync` for sync use cases — it is built on the Turso Database engine with better performance, true local-first writes, and concurrent write support. See the [quickstart](/sdk/python/quickstart).
+For workloads that need **offline writes**, **bidirectional sync**, or **multi-writer convergence**, we recommend `turso.sync` — both reads and writes are local, and you sync explicitly with `push()` / `pull()`. See the [quickstart](/sdk/python/quickstart).
 
-</Warning>
+</Info>
 
 You can work with [embedded replicas](/features/embedded-replicas) that can sync from the remote database to a local SQLite file, and delegate writes to the remote primary database:
 

--- a/sdk/python/reference.mdx
+++ b/sdk/python/reference.mdx
@@ -7,7 +7,7 @@ Turso offers two Python packages:
 
 | | `pyturso` | `libsql` |
 | --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Embedded Replicas (cloud-replicated reads) |
+| **Use case** | Local / embedded database, sync | Existing libSQL codebases |
 | **Engine** | Turso Database (rewrite) | libSQL (SQLite fork) |
 | **Concurrent writes** | Yes (MVCC) | Not supported |
 | **Sync** | push/pull (local-first) | Embedded Replicas (writes go to cloud primary) |
@@ -75,11 +75,11 @@ Turso Cloud databases can also be encrypted with bring-your-own-key — [learn m
 
 ## libsql (libSQL)
 
-The `libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you need Embedded Replicas or are working with an existing `libsql`-based codebase.
+The `libsql` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you are working with an existing `libsql`-based codebase.
 
 <Info>
 
-With `libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. This is fully supported and ideal when the cloud is your source of truth. If you need local-first writes (offline, multi-writer, or bidirectional sync), use `turso.sync` — see the [quickstart](/sdk/python/quickstart).
+With `libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. Embedded Replicas are fully supported. For new projects that need sync, we recommend `turso.sync` — see the [quickstart](/sdk/python/quickstart).
 
 </Info>
 

--- a/sdk/rust/quickstart.mdx
+++ b/sdk/rust/quickstart.mdx
@@ -163,9 +163,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 <Info>
 
-Embedded Replicas give your Rust app a local read copy of a Turso Cloud database. Reads are served locally; writes go to the cloud primary and are reflected back to the replica. This model is fully supported in production and is a good fit for server and VM deployments that want low-latency reads with a single cloud source of truth.
+Embedded Replicas give your Rust app a local read copy of a Turso Cloud database. Reads are served locally; writes go to the cloud primary and are reflected back to the replica. Embedded Replicas are fully supported in production.
 
-For workloads that need **offline writes**, **bidirectional sync**, or **multi-writer convergence**, prefer the `turso` crate with `turso::sync`: both reads and writes are local, you sync explicitly with `push()` / `pull()`, and the wire format is logical change-data-capture rather than page frames ([benchmark](https://turso.tech/blog/sync-benchmark)).
+For new projects that need sync, we recommend the `turso` crate with `turso::sync`: both reads and writes are local, you sync explicitly with `push()` / `pull()`, and the wire format is logical change-data-capture rather than page frames ([benchmark](https://turso.tech/blog/sync-benchmark)).
 
 </Info>
 

--- a/sdk/rust/quickstart.mdx
+++ b/sdk/rust/quickstart.mdx
@@ -159,12 +159,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   </Step>
 </Steps>
 
-## Legacy: libsql (Embedded Replicas)
+## Embedded Replicas (libsql)
 
-<Warning>
+<Info>
 
-**Usage of embedded replicas is strongly discouraged.** With embedded replicas, reads are local but **writes are sent to the remote database** — this means writes fail when offline, have higher latency, and don't support concurrent writes. Use the `turso` crate with `turso::sync` instead: all reads and writes are local, and you explicitly sync with `push()` / `pull()`.
+Embedded Replicas give your Rust app a local read copy of a Turso Cloud database. Reads are served locally; writes go to the cloud primary and are reflected back to the replica. This model is fully supported in production and is a good fit for server and VM deployments that want low-latency reads with a single cloud source of truth.
 
-</Warning>
+For workloads that need **offline writes**, **bidirectional sync**, or **multi-writer convergence**, prefer the `turso` crate with `turso::sync`: both reads and writes are local, you sync explicitly with `push()` / `pull()`, and the wire format is logical change-data-capture rather than page frames ([benchmark](https://turso.tech/blog/sync-benchmark)).
 
-See the [reference](/sdk/rust/reference) for legacy documentation on embedded replicas if you have an existing `libsql` codebase.
+</Info>
+
+See the [reference](/sdk/rust/reference) for full documentation on Embedded Replicas with `libsql`.

--- a/sdk/rust/reference.mdx
+++ b/sdk/rust/reference.mdx
@@ -5,12 +5,12 @@ description: Rust Reference for Turso
 
 Turso offers two Rust crates:
 
-| | `turso` | `libsql` (legacy) |
+| | `turso` | `libsql` |
 | --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Remote access, legacy embedded replicas |
+| **Use case** | Local / embedded database, sync | Remote access, Embedded Replicas (cloud-replicated reads) |
 | **Engine** | Turso Database (rewrite) | libSQL (SQLite fork) |
 | **Concurrent writes** | Yes (MVCC) | Not supported |
-| **Sync** | push/pull (true local-first) | Embedded replicas (writes go to remote) |
+| **Sync** | push/pull (local-first) | Embedded Replicas (writes go to cloud primary) |
 | **C compiler** | Not required | Required for `core`, `replication`, `encryption` features |
 
 **Starting a new project?** Use `turso` for local/embedded use or sync. Use `libsql` with the `remote` feature for over-the-wire access (no C compiler needed).
@@ -186,25 +186,19 @@ let conn = db.connect()?;
 let mut rows = conn.query("SELECT * FROM users WHERE id = ?1", [1]).await?;
 ```
 
-## libsql (Legacy)
+## libsql (libSQL)
 
-The `libsql` crate is built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. It is fully supported — if you run into something that doesn't work yet with the `turso` crate, `libsql` is a reliable fallback.
+The `libsql` crate is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you need Embedded Replicas or are working with an existing `libsql`-based codebase.
 
 <Info>
 
-With `libsql` embedded replicas, reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use the `turso` crate with `turso::sync` — see the [quickstart](/sdk/rust/quickstart).
+With `libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. This is fully supported and ideal when the cloud is your source of truth. If you need local-first writes (offline, multi-writer, or bidirectional sync), use the `turso` crate with `turso::sync` — see the [quickstart](/sdk/rust/quickstart).
 
 </Info>
 
 ### Embedded Replicas
 
-<Warning>
-
-**Usage of embedded replicas is strongly discouraged.** Use the `turso` crate with `turso::sync` instead — it is built on the Turso Database engine with better performance, true local-first writes, and concurrent write support.
-
-</Warning>
-
-You can work with [embedded replicas](/features/embedded-replicas) that can sync from the remote database to a local SQLite file, and delegate writes to the remote primary database:
+You can work with [Embedded Replicas](/features/embedded-replicas) that sync from a Turso Cloud database to a local SQLite file. Reads run locally; writes are sent to the cloud primary and then reflected back to the replica:
 
 ```rust
 use libsql::Builder;

--- a/sdk/rust/reference.mdx
+++ b/sdk/rust/reference.mdx
@@ -7,7 +7,7 @@ Turso offers two Rust crates:
 
 | | `turso` | `libsql` |
 | --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Remote access, Embedded Replicas (cloud-replicated reads) |
+| **Use case** | Local / embedded database, sync | Remote access, existing libSQL codebases |
 | **Engine** | Turso Database (rewrite) | libSQL (SQLite fork) |
 | **Concurrent writes** | Yes (MVCC) | Not supported |
 | **Sync** | push/pull (local-first) | Embedded Replicas (writes go to cloud primary) |
@@ -188,11 +188,11 @@ let mut rows = conn.query("SELECT * FROM users WHERE id = ?1", [1]).await?;
 
 ## libsql (libSQL)
 
-The `libsql` crate is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you need Embedded Replicas or are working with an existing `libsql`-based codebase.
+The `libsql` crate is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready and battle-tested, and is the right choice when you are working with an existing `libsql`-based codebase.
 
 <Info>
 
-With `libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. This is fully supported and ideal when the cloud is your source of truth. If you need local-first writes (offline, multi-writer, or bidirectional sync), use the `turso` crate with `turso::sync` — see the [quickstart](/sdk/rust/quickstart).
+With `libsql` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. Embedded Replicas are fully supported. For new projects that need sync, we recommend the `turso` crate with `turso::sync` — see the [quickstart](/sdk/rust/quickstart).
 
 </Info>
 

--- a/sdk/ts/quickstart.mdx
+++ b/sdk/ts/quickstart.mdx
@@ -146,7 +146,7 @@ const row = await stmt.get([1]);
 
 ## @libsql/client
 
-Use `@libsql/client` for ORM integration (Drizzle, Prisma), Embedded Replicas, or if you have an existing codebase built on it. See the [reference](/sdk/ts/reference#libsqlclient) for full documentation.
+Use `@libsql/client` for ORM integration (Drizzle, Prisma) or if you have an existing codebase built on it. See the [reference](/sdk/ts/reference#libsqlclient) for full documentation.
 
 <Steps>
   <Step title="Install">

--- a/sdk/ts/quickstart.mdx
+++ b/sdk/ts/quickstart.mdx
@@ -144,9 +144,9 @@ const row = await stmt.get([1]);
   </Step>
 </Steps>
 
-## @libsql/client (ORM & Legacy)
+## @libsql/client
 
-Use `@libsql/client` for ORM integration (Drizzle, Prisma) or if you have an existing codebase built on it. See the [reference](/sdk/ts/reference#libsql-client-legacy) for full documentation.
+Use `@libsql/client` for ORM integration (Drizzle, Prisma), Embedded Replicas, or if you have an existing codebase built on it. See the [reference](/sdk/ts/reference#libsqlclient) for full documentation.
 
 <Steps>
   <Step title="Install">
@@ -168,7 +168,7 @@ await turso.execute("SELECT * FROM users");
   </Step>
   <Step title="Sync">
 
-If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides true local-first sync with explicit `push()` and `pull()` operations.
+If you need to sync your local database with a remote Turso Cloud database (local reads and writes with push/pull to the cloud), use [Turso Sync](/sync/usage). Turso Sync is built on the Turso Database engine and provides local-first sync with explicit `push()` and `pull()` operations.
 
   </Step>
 </Steps>

--- a/sdk/ts/reference.mdx
+++ b/sdk/ts/reference.mdx
@@ -7,7 +7,7 @@ Turso offers three TypeScript packages:
 
 | | `@tursodatabase/database` | `@tursodatabase/sync` | `@tursodatabase/serverless` | `@libsql/client` |
 | --- | --- | --- | --- | --- |
-| **Use case** | Local / embedded database | Local database + cloud sync | Remote access (servers, containers, serverless, edge) | ORM support, Embedded Replicas |
+| **Use case** | Local / embedded database | Local database + cloud sync | Remote access (servers, containers, serverless, edge) | ORM support (Drizzle, Prisma) |
 | **Engine** | Turso Database (rewrite) | Turso Database (rewrite) | Turso Database | libSQL (SQLite fork) |
 | **Dependencies** | Native (Node.js, WASM) | Native (Node.js) | `fetch` only — zero native deps | Requires Node.js or `/web` subpath |
 | **Concurrent writes** | Yes (MVCC) | Yes (MVCC) | Planned | Not supported |
@@ -183,11 +183,11 @@ const row = await stmt2.get([1]);
 
 ## @libsql/client
 
-The `@libsql/client` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready, battle-tested, and the right choice when you need ORM integration beyond Drizzle (e.g., Prisma), Embedded Replicas, or are working with an existing `@libsql/client`-based codebase.
+The `@libsql/client` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready, battle-tested, and the right choice when you need ORM integration beyond Drizzle (e.g., Prisma) or are working with an existing `@libsql/client`-based codebase.
 
 <Info>
 
-With `@libsql/client` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. This is fully supported and ideal when the cloud is your source of truth. If you need local-first writes (offline, multi-writer, or bidirectional sync), use `@tursodatabase/sync` with [Turso Sync](/sync/usage).
+With `@libsql/client` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. Embedded Replicas are fully supported. For new projects that need sync, we recommend `@tursodatabase/sync` with [Turso Sync](/sync/usage).
 
 </Info>
 

--- a/sdk/ts/reference.mdx
+++ b/sdk/ts/reference.mdx
@@ -5,13 +5,13 @@ description: TypeScript Reference for Turso
 
 Turso offers three TypeScript packages:
 
-| | `@tursodatabase/database` | `@tursodatabase/sync` | `@tursodatabase/serverless` | `@libsql/client` (legacy) |
+| | `@tursodatabase/database` | `@tursodatabase/sync` | `@tursodatabase/serverless` | `@libsql/client` |
 | --- | --- | --- | --- | --- |
-| **Use case** | Local / embedded database | Local database + cloud sync | Remote access (servers, containers, serverless, edge) | Legacy — ORM support |
+| **Use case** | Local / embedded database | Local database + cloud sync | Remote access (servers, containers, serverless, edge) | ORM support, Embedded Replicas |
 | **Engine** | Turso Database (rewrite) | Turso Database (rewrite) | Turso Database | libSQL (SQLite fork) |
 | **Dependencies** | Native (Node.js, WASM) | Native (Node.js) | `fetch` only — zero native deps | Requires Node.js or `/web` subpath |
 | **Concurrent writes** | Yes (MVCC) | Yes (MVCC) | Planned | Not supported |
-| **Sync** | — | push/pull (true local-first) | — | Embedded replicas (writes go to remote) |
+| **Sync** | — | push/pull (local-first) | — | Embedded Replicas (writes go to cloud primary) |
 | **ORM support** | Drizzle (beta) | — | — | Drizzle, Prisma, and others |
 
 **Starting a new project?** Use `@tursodatabase/database` for local/embedded use, `@tursodatabase/sync` for local + cloud sync, or `@tursodatabase/serverless` for any application that connects to a remote Turso Cloud database (Node.js servers, Docker containers, serverless functions, edge runtimes). **Using an ORM?** Use `@libsql/client` — it's production-ready and supported by Drizzle, Prisma, and others. Drizzle has [beta support](https://orm.drizzle.team/docs/connect-turso-database) for `@tursodatabase/database` for local/embedded use.
@@ -181,13 +181,13 @@ const stmt2 = await conn.prepare("SELECT * FROM users WHERE id = ?");
 const row = await stmt2.get([1]);
 ```
 
-## @libsql/client (Legacy)
+## @libsql/client
 
-The `@libsql/client` package is built on [libSQL](https://github.com/tursodatabase/libsql), our open-source fork of SQLite that predated the Turso Database engine. It is fully supported and battle-tested — if you run into something that doesn't work yet with the newer Turso packages, `@libsql/client` is a reliable fallback. It's also the right choice if you need ORM integration beyond Drizzle (e.g., Prisma) or are working with an existing `@libsql/client`-based codebase.
+The `@libsql/client` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready, battle-tested, and the right choice when you need ORM integration beyond Drizzle (e.g., Prisma), Embedded Replicas, or are working with an existing `@libsql/client`-based codebase.
 
 <Info>
 
-With `@libsql/client` embedded replicas, reads are local but **writes go to the remote database**. For true local-first writes with push/pull sync, use `@tursodatabase/sync` with [Turso Sync](/sync/usage).
+With `@libsql/client` Embedded Replicas, reads are local and writes are sent to the cloud primary, then reflected back to the replica. This is fully supported and ideal when the cloud is your source of truth. If you need local-first writes (offline, multi-writer, or bidirectional sync), use `@tursodatabase/sync` with [Turso Sync](/sync/usage).
 
 </Info>
 
@@ -238,11 +238,11 @@ The `@libsql/client/web` does not support local file URLs.
 
 ### Embedded Replicas
 
-<Warning>
+<Info>
 
-For new projects, we recommend [`@tursodatabase/sync`](#tursodatabasesync) for sync use cases — it is built on the Turso Database engine with better performance, true local-first writes, and concurrent write support.
+For workloads that need **offline writes**, **bidirectional sync**, or **multi-writer convergence**, we recommend [`@tursodatabase/sync`](#tursodatabasesync) — both reads and writes are local, and you sync explicitly with `push()` / `pull()`.
 
-</Warning>
+</Info>
 
 You can work with embedded replicas by passing your Turso Database URL to `syncUrl`:
 

--- a/sync/usage.mdx
+++ b/sync/usage.mdx
@@ -344,4 +344,4 @@ syncWhenOnline(ctx, db)
 
 </CodeGroup>
 
-This replaces the `offline: true` flag from the legacy [`@libsql/client` embedded replicas](/features/embedded-replicas/introduction) API. With Turso Sync, all reads and writes happen locally by default — you control when to sync with explicit `push()` and `pull()` calls.
+This is the modern equivalent of the `offline: true` flag from [`@libsql/client` Embedded Replicas](/features/embedded-replicas/introduction). With Turso Sync, all reads and writes happen locally by default — you control when to sync with explicit `push()` and `pull()` calls.


### PR DESCRIPTION
## Summary

A regulated-industry production user reported that the "deprecated" / "strongly discouraged" / "legacy" framing around the libSQL SDKs was costing them business — they had no "production-ready" SDK to point at internally. The previous wording implied these products were unsupported or being phased out, which is not true.

This PR reframes the docs to position the libSQL SDK packages as production-ready peer choices, while still actively recommending Turso Sync for new sync workloads.

**Key positioning:**

- **libSQL SDK packages** (`@libsql/client`, `libsql`, `go-libsql`) → production-ready, battle-tested. Recommended for ORM integration and existing codebases.
- **Embedded Replicas** → described as a fully supported feature, but not promoted as a recommended use case for the libSQL SDKs. The docs steer new projects toward Turso Sync.
- **Turso Sync** → the recommendation for new projects that need sync, backed by the [sync benchmark blog](https://turso.tech/blog/sync-benchmark) (logical CDC, lower bandwidth, push/pull).

**What changed:**

- Drops `(Legacy)`, "Legacy:", and "strongly discouraged" headings/warnings on libSQL packages and Embedded Replicas.
- Removes "predated the Turso Database engine" framing in favor of "powers Turso Cloud today."
- Drops the "true local-first" qualifier, which implicitly framed Embedded Replicas as fake-local-first.
- Converts `<Warning>` blocks around ER to `<Info>` blocks with a neutral "Embedded Replicas are fully supported. For new projects that need sync, we recommend Turso Sync." pattern.
- Drops ER from the libSQL package use-case lists so we are not promoting it; the dedicated ER pages still document it as a supported feature.

**Files touched (11):**

- `features/embedded-replicas/introduction.mdx`
- `sdk/introduction.mdx`
- `sdk/go/quickstart.mdx`, `sdk/go/reference.mdx`
- `sdk/python/quickstart.mdx`, `sdk/python/reference.mdx`
- `sdk/rust/quickstart.mdx`, `sdk/rust/reference.mdx`
- `sdk/ts/quickstart.mdx`, `sdk/ts/reference.mdx`
- `sync/usage.mdx`

## Test plan

- [ ] Render the docs site locally and review all 11 modified pages.
- [ ] Verify the `#libsqlclient` anchor link in `sdk/ts/quickstart.mdx` resolves to the renamed `## @libsql/client` heading in `sdk/ts/reference.mdx`.
- [ ] Spot-check links to `/sync/usage` and the benchmark blog post.
- [ ] Confirm no remaining "deprecated" / "strongly discouraged" / "(Legacy)" framing on customer-facing libSQL or Embedded Replicas docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
