### PR TITLE
Added warning about invites paid plan only limitation

### DIFF
--- a/api-reference/audit-logs/list.mdx
+++ b/api-reference/audit-logs/list.mdx
@@ -3,7 +3,7 @@ sidebarTitle: List
 openapi: "GET /v1/organizations/{organizationSlug}/audit-logs"
 ---
 
-<Warning>Audit Logs are limited to paid plans.</Warning>
+<Warning>Audit Logs are limited to scaler plan and above.</Warning>
 
 <RequestExample>
 

--- a/api-reference/organizations/invites/create-v2.mdx
+++ b/api-reference/organizations/invites/create-v2.mdx
@@ -3,6 +3,8 @@ title: Create Invite
 openapi: "POST /v2/organizations/{organizationSlug}/invites"
 ---
 
+<Warning>Invites are limited to paid plans.</Warning>
+
 <Info>
 
 You can invite by **email** or by **username** — provide exactly one. When inviting by username, the invite is sent to that user's registered email.

--- a/api-reference/organizations/invites/create-v2.mdx
+++ b/api-reference/organizations/invites/create-v2.mdx
@@ -3,7 +3,7 @@ title: Create Invite
 openapi: "POST /v2/organizations/{organizationSlug}/invites"
 ---
 
-<Warning>Invites are limited to paid plans.</Warning>
+<Warning>Invites are limited to scaler plan and above.</Warning>
 
 <Info>
 

--- a/api-reference/organizations/invites/delete-v2.mdx
+++ b/api-reference/organizations/invites/delete-v2.mdx
@@ -3,7 +3,7 @@ sidebarTitle: Delete Invite
 openapi: "DELETE /v2/organizations/{organizationSlug}/invites/{email}"
 ---
 
-<Warning>Invites are limited to paid plans.</Warning>
+<Warning>Invites are limited to scaler plan and above.</Warning>
 
 <RequestExample>
 

--- a/api-reference/organizations/invites/delete-v2.mdx
+++ b/api-reference/organizations/invites/delete-v2.mdx
@@ -3,6 +3,8 @@ sidebarTitle: Delete Invite
 openapi: "DELETE /v2/organizations/{organizationSlug}/invites/{email}"
 ---
 
+<Warning>Invites are limited to paid plans.</Warning>
+
 <RequestExample>
 
 ```bash cURL


### PR DESCRIPTION
Invites listing is accessible to any user plan.
Invitation creation and deletion is limited to paid plans. 