### PR TITLE
Add Toasty ORM docs for Rust SDK

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -279,6 +279,12 @@
                           "sdk/rust/guides/rocket",
                           "sdk/rust/guides/tauri"
                         ]
+                      },
+                      {
+                        "group": "ORMs",
+                        "pages": [
+                          "sdk/rust/orm/toasty"
+                        ]
                       }
                     ]
                   },

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -16,7 +16,11 @@ title: Turso SDKs
 
 **Need sync?** Use [Turso Sync](/sync/usage) for local reads and writes with explicit `push()` / `pull()` to Turso Cloud.
 
-**Using an ORM (Drizzle, Prisma)?** Use `@libsql/client` — it has production-ready support from all major ORMs in the ecosystem.
+**Using an ORM?**
+
+- **TypeScript** — Drizzle and Prisma run on `@libsql/client` with production-ready support from all major ORMs in the ecosystem.
+- **Rust** — [Toasty](/sdk/rust/orm/toasty), the async ORM from the Tokio project, has a native Turso driver built on the `turso` crate.
+- **Python** — see the [SQLAlchemy guide](/sdk/python/orm/sqlalchemy).
 
 **Migrating from SQLite?** Turso Database is a drop-in replacement. Your existing SQL, schema, and queries work unchanged.
 

--- a/sdk/rust/orm/toasty.mdx
+++ b/sdk/rust/orm/toasty.mdx
@@ -1,0 +1,156 @@
+---
+title: Toasty + Turso
+sidebarTitle: Toasty
+description: Use Toasty, the async ORM from the Tokio project, with Turso Database.
+---
+
+[Toasty](https://github.com/tokio-rs/toasty) is an async ORM for Rust maintained by the [Tokio](https://tokio.rs/) project. It ships a native Turso driver (`toasty-driver-turso`) that connects to a local Turso Database file or an in-memory database — the same engine you get from the [`turso` crate](/sdk/rust/quickstart).
+
+<Info>
+
+The Toasty Turso driver currently targets local and in-memory databases. For sync against Turso Cloud, drop down to the [`turso` crate directly](/sdk/rust/quickstart#sync-push-and-pull).
+
+</Info>
+
+## Prerequisites
+
+- Rust 1.95 or newer (Toasty's minimum supported version)
+- A Rust project (`cargo init`)
+- Tokio as your async runtime
+
+<Steps>
+
+<Step title="Install Toasty with the Turso driver">
+
+```bash
+cargo add toasty --features turso
+cargo add tokio --features full
+cargo add uuid
+```
+
+</Step>
+
+<Step title="Define your models">
+
+Toasty derives schema, queries, and relations from plain Rust structs:
+
+```rust models.rs
+#[derive(Debug, toasty::Model)]
+struct User {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    name: String,
+
+    #[unique]
+    email: String,
+
+    #[has_many]
+    todos: toasty::Deferred<Vec<Todo>>,
+}
+
+#[derive(Debug, toasty::Model)]
+struct Todo {
+    #[key]
+    #[auto]
+    id: uuid::Uuid,
+
+    #[index]
+    user_id: uuid::Uuid,
+
+    #[belongs_to(key = user_id, references = id)]
+    user: toasty::Deferred<User>,
+
+    title: String,
+}
+```
+
+</Step>
+
+<Step title="Connect to Turso">
+
+Pass a `turso:` URL to `Db::builder` — either an in-memory database or a file path:
+
+<AccordionGroup>
+  <Accordion title="In-memory">
+
+```rust
+let db = toasty::Db::builder()
+    .models(toasty::models!(crate::*))
+    .connect("turso::memory:")
+    .await?;
+```
+
+  </Accordion>
+  <Accordion title="File-backed">
+
+```rust
+let db = toasty::Db::builder()
+    .models(toasty::models!(crate::*))
+    .connect("turso:./app.db")
+    .await?;
+```
+
+  </Accordion>
+  <Accordion title="With concurrent writes (MVCC)">
+
+To enable Turso's MVCC journal so multiple writers can run concurrently, build the driver explicitly and pass it to `build()`:
+
+```rust
+use toasty_driver_turso::Turso;
+
+let driver = Turso::file("app.db").concurrent_writes();
+
+let db = toasty::Db::builder()
+    .models(toasty::models!(crate::*))
+    .build(driver)
+    .await?;
+```
+
+When `concurrent_writes()` is enabled, write-write conflicts surface as a serialization failure — check `err.is_serialization_failure()` and retry the transaction.
+
+  </Accordion>
+</AccordionGroup>
+
+</Step>
+
+<Step title="Create the schema and query">
+
+```rust
+#[tokio::main]
+async fn main() -> toasty::Result<()> {
+    let mut db = toasty::Db::builder()
+        .models(toasty::models!(crate::*))
+        .connect("turso:./app.db")
+        .await?;
+
+    db.push_schema().await?;
+
+    let user = toasty::create!(User {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+    })
+    .exec(&mut db)
+    .await?;
+
+    toasty::create!(in user.todos() { title: "ship Toasty + Turso" })
+        .exec(&mut db)
+        .await?;
+
+    let reloaded = User::get_by_email(&mut db, &user.email).await?;
+    println!("{reloaded:#?}");
+
+    Ok(())
+}
+```
+
+</Step>
+
+</Steps>
+
+## Where to go next
+
+- The [Toasty guide](https://tokio-rs.github.io/toasty/) covers models, relations, transactions, and migrations.
+- The [Turso chapter](https://tokio-rs.github.io/toasty/nightly/guide/turso.html) of the Toasty guide documents the connection URL forms, the `concurrent_writes()` flag, and the `experimental_*` toggles for Turso's engine features.
+- The [`turso` crate quickstart](/sdk/rust/quickstart) shows how to use Turso Database directly without an ORM, including sync against Turso Cloud.

--- a/sdk/rust/quickstart.mdx
+++ b/sdk/rust/quickstart.mdx
@@ -159,6 +159,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   </Step>
 </Steps>
 
+## Using an ORM
+
+[Toasty](/sdk/rust/orm/toasty), the async ORM from the Tokio project, has a native Turso driver. It speaks to the `turso` crate directly, so you get a typed model layer (`#[derive(toasty::Model)]`, derived queries, relations) over the same Turso Database engine used in the quickstart above.
+
+```bash
+cargo add toasty --features turso
+```
+
+See the [Toasty + Turso guide](/sdk/rust/orm/toasty) for the full walkthrough.
+
 ## Embedded Replicas (libsql)
 
 <Info>


### PR DESCRIPTION
## Summary

- Toasty (the async ORM from the Tokio project) ships a native Turso driver (`toasty-driver-turso`). This PR documents it as the first-party Rust ORM story for Turso.
- New page `sdk/rust/orm/toasty.mdx` — Toasty + Turso quickstart with in-memory, file-backed, and `concurrent_writes()` (MVCC) variants, plus a runnable example.
- Updated `sdk/rust/quickstart.mdx` — adds a short "Using an ORM" section linking to the new page.
- Updated `sdk/introduction.mdx` — replaces the "Using an ORM (Drizzle, Prisma)?" bullet with a per-language list (TypeScript → Drizzle/Prisma, Rust → Toasty, Python → SQLAlchemy).
- Wired the new page into `docs.json` under an `ORMs` subgroup in the Rust SDK.

### Scope caveat (called out in the new page)

Toasty's Turso driver currently only supports local file-backed and in-memory databases — there is no remote/sync URL form yet. The new page surfaces this in an `<Info>` block and points users at the `turso` crate for Turso Cloud sync. When/if Toasty grows a sync URL, the page should be updated.

## Test plan

- [x] `docs.json` parses (validated locally with `python3 -m json.tool`).
- [x] **Every Rust snippet compiled and the end-to-end example ran** against the published crates — `toasty 0.7.0` (`--features turso`) and `toasty-driver-turso 0.7.0` from crates.io, Rust 1.95. Verified: model derivation, `connect("turso::memory:")`, `connect("turso:./app.db")`, the `Turso::file(...).concurrent_writes()` + `build()` path, `push_schema()`, `create!`, nested `create!(in user.todos() { ... })`, the generated `User::get_by_email`, and `err.is_serialization_failure()`.
- [ ] Mintlify preview renders the new `sdk/rust/orm/toasty` page and lists it under Rust → ORMs in the sidebar.
- [ ] Links from the SDK introduction and Rust quickstart to `/sdk/rust/orm/toasty` resolve.

### API corrections from the smoke test

The first draft was written against Toasty's `main` branch before 0.7.0 published. The published 0.7.0 API differs, and this PR matches the release:

- Relation fields are `toasty::Deferred<Vec<T>>` (has-many) and `toasty::Deferred<T>` (belongs-to). The old `toasty::HasMany<T>` / `toasty::BelongsTo<T>` wrapper types are gone.
- Serialization conflicts are detected with `err.is_serialization_failure()`; there is no public `Error::SerializationFailure` variant to match on.
- Added a Rust 1.95 MSRV note to the prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
