### PR TITLE
Document group-scoped Platform API tokens; deprecate unrestricted

### DIFF
--- a/api-reference/authentication.mdx
+++ b/api-reference/authentication.mdx
@@ -5,17 +5,32 @@ description:
 
 The Turso API uses API tokens to authenticate requests. You can create and revoke API tokens using the [Turso CLI](/cli) and [Authentication API](/api-reference/tokens/create).
 
-API tokens can be scoped to a single organization using `--org` when minting them, restricting the token to only manage resources within that organization. Without `--org`, a token grants access to all organizations your account belongs to.
+Tokens can be minted at three levels of restriction:
+
+| Restriction | What it can do | How to mint |
+| --- | --- | --- |
+| Organization-scoped | Restricted to a single organization. | `turso auth api-tokens mint my-token --org my-org` |
+| Group-scoped | Pinned to one group inside an organization, with a chosen set of permissions. | `turso auth api-tokens mint my-token --org my-org --group default --read-only` |
+| Unrestricted *(deprecated)* | Acts on every organization the caller belongs to. | `turso auth api-tokens mint my-token` |
+
+<Warning>
+
+**Unrestricted (cross-org) tokens are deprecated and will be removed in a future release.** New tokens should always be scoped to an organization with `--org`. Existing unrestricted tokens continue to work for now, but you should rotate them to scoped tokens at your earliest convenience.
+
+</Warning>
 
 ```bash
 # Token scoped to a single organization
 turso auth api-tokens mint my-token --org my-org
 
-# Token with access to all organizations (default)
+# Group-scoped token, read-only (tighter scope, for automations that only need one group)
+turso auth api-tokens mint my-token --org my-org --group default --read-only
+
+# Token with access to all organizations — deprecated
 turso auth api-tokens mint my-token
 ```
 
-- Scope tokens to the minimum organization needed, especially in CI/CD and production environments.
+- Scope tokens to a single organization with `--org`, especially in CI/CD and production environments.
 - Use environment variables when working with API tokens.
 - Never share your API token in public, including repositories, and CI/CD Actions.
 
@@ -24,6 +39,64 @@ Turso uses Bearer authentication, and requires your API token to be passed with 
 ```bash
 Authorization: Bearer TOKEN
 ```
+
+## Group-scoped tokens
+
+A group-scoped token is a Platform API credential pinned to one group inside an organization, with an explicit list of allowed operations. It's the right shape for automations that should be able to provision and manage databases inside a single group without being able to reach the rest of the organization.
+
+The caller minting a group-scoped token must be an admin or owner of the organization.
+
+<Note>
+
+Group-scoped tokens are control-plane credentials — they authorize requests to the Turso Platform API. They are independent from the [SQL-engine tokens](/sdk/authorization/tokens) that your application uses to query a database. The two systems do not share key material or vocabulary.
+
+</Note>
+
+### Scope vocabulary
+
+The platform expands the presets `read-only` and `full-access` to the corresponding individual scopes server-side, so the values you see on a token after creation are always individual scopes.
+
+| Scope | Allows |
+| --- | --- |
+| `read` | All GET-style routes: list/retrieve databases and groups, configuration, usage, instances, locations. |
+| `db:create` | Create databases inside the group (`POST /databases`), seed from a dump, restore. |
+| `db:delete` | Delete a database inside the group. |
+| `db:configure` | Patch database configuration, transfer, wake, add or remove instances. |
+| `db:mint-token` | Issue a SQL-engine token or TLS client certificate for a database inside the group. |
+| `db:rotate-creds` | Rotate the database signing key, invalidating every SQL token previously issued for it. |
+| `group:configure` | Configure, rename, update, unarchive the group, or add and remove locations. |
+| `group:mint-token` | Issue a group-level SQL-engine token. |
+| `group:rotate-creds` | Rotate the group signing key, invalidating every SQL token issued against any database in the group. |
+
+<Warning>
+
+`db:mint-token` and `db:rotate-creds` are deliberately separate scopes. Minting a new SQL credential is additive; rotating invalidates every credential currently in use, which can take down running applications. Grant rotation only to automations that need it.
+
+</Warning>
+
+### Presets
+
+| Preset | Expands to |
+| --- | --- |
+| `read-only` | `read` |
+| `full-access` | Every individual scope listed above. |
+
+Group create, group delete, group transfer, and AWS migration are intentionally not reachable from a group-scoped token at any scope — those operations are gated to organization-level credentials.
+
+### Lifecycle
+
+- Group-scoped tokens are pinned by the group's UUID, not its name. If a group is deleted and a new one is created with the same name, old tokens do not transfer — they are revoked along with the group.
+- Deleting a group cascades a revoke to every token scoped to it.
+- Transferring a group to a different organization cascades a revoke to every token scoped to it.
+
+### Managing organization tokens
+
+Two endpoints let admins manage every token scoped to an organization in one place — they are what backs the dashboard's organization-level token table:
+
+- [`GET /v1/organizations/{organizationSlug}/api-tokens`](/api-reference/tokens/list-organization) — list every org-scoped and group-scoped token, with the minting user attached.
+- [`DELETE /v1/organizations/{organizationSlug}/api-tokens/{tokenId}`](/api-reference/tokens/revoke-organization) — revoke by ID.
+
+Members and viewers can call the same endpoints, but only see and revoke tokens they minted themselves.
 
 ## Base URL
 

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1953,7 +1953,7 @@
     "/v1/auth/api-tokens/{tokenName}": {
       "post": {
         "summary": "Create API Token",
-        "description": "Returns a new API token belonging to a user. You can optionally restrict the token to a single organization by passing the organization slug in the request body. Organization-scoped tokens can only manage resources within that organization.",
+        "description": "Returns a new API token belonging to a user.\n\nThe token can be minted at three levels of restriction, in increasing order of narrowness:\n\n- **Organization-scoped** — pass `organization`. The token can only act on resources inside that organization.\n- **Group-scoped** — pass `organization`, `group`, and `scopes`. The token is pinned to a single group inside the organization and only the operations listed in `scopes` are allowed. The caller must be an admin or owner of the organization.\n- **Unrestricted** *(deprecated)* — no request body. The token can act on every organization the caller belongs to. **Unrestricted tokens are deprecated and will be removed in a future release.** Always pass `organization` for new tokens and rotate existing unrestricted tokens to scoped tokens.\n\nGroup-scoped tokens are designed for automations that should be able to provision and manage databases inside a single group without being able to touch the rest of the organization.",
         "operationId": "createAPIToken",
         "parameters": [
           {
@@ -1961,7 +1961,7 @@
           }
         ],
         "requestBody": {
-          "description": "Optional organization restriction for the token.",
+          "description": "Optional restriction for the token. Omit the body for an unrestricted token, pass `organization` alone for an org-scoped token, or pass `organization` + `group` + `scopes` for a group-scoped token.",
           "required": false,
           "content": {
             "application/json": {
@@ -1970,8 +1970,34 @@
                 "properties": {
                   "organization": {
                     "type": "string",
-                    "description": "The organization slug to restrict this token to. If omitted, the token grants access to all organizations the user belongs to.",
+                    "description": "The organization slug to restrict this token to. Required when `group` is set.",
                     "example": "my-org"
+                  },
+                  "group": {
+                    "type": "string",
+                    "description": "The group name (inside `organization`) to restrict this token to. Requires `organization` and a non-empty `scopes` list.",
+                    "example": "default"
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "read",
+                        "db:create",
+                        "db:delete",
+                        "db:configure",
+                        "db:mint-token",
+                        "db:rotate-creds",
+                        "group:configure",
+                        "group:mint-token",
+                        "group:rotate-creds",
+                        "read-only",
+                        "full-access"
+                      ]
+                    },
+                    "description": "Permissions to grant a group-scoped token. Each entry is either an individual scope or one of the presets `read-only` (expands to `read`) and `full-access` (expands to every scope). Required and must be non-empty when `group` is set. `db:mint-token` lets the token issue new SQL credentials; `db:rotate-creds` invalidates every existing SQL token for the database — they are deliberately separate because rotation is destructive.",
+                    "example": ["db:create", "db:configure", "db:mint-token"]
                   }
                 }
               }
@@ -2023,6 +2049,128 @@
                       "type": "string",
                       "description": "The revoked token name.",
                       "example": "..."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/organizations/{organizationSlug}/api-tokens": {
+      "get": {
+        "summary": "List Organization API Tokens",
+        "description": "Returns the API tokens scoped to this organization (both organization-scoped and group-scoped). Unrestricted tokens are not returned here — manage those via [`GET /v1/auth/api-tokens`](/api-reference/tokens/list).\n\nAuthorization is symmetric with the revoke endpoint:\n\n- **Admins and owners** see every token scoped to the organization, with the minting user attached in the `owner` field.\n- **Members and viewers** see only tokens they minted themselves.\n\nThis mirrors the personal-access-token model used in GitHub organization settings: admins get the full attribution list; everyone else sees their own access.",
+        "operationId": "listOrganizationAPITokens",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/organizationSlug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tokens": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The token name.",
+                            "example": "ci-bot"
+                          },
+                          "id": {
+                            "type": "string",
+                            "description": "The token ID. Pass this to the revoke endpoint.",
+                            "example": "clGFZ4STEe6fljpFzIum8A"
+                          },
+                          "organization": {
+                            "type": "string",
+                            "description": "The organization slug. Always equal to the path parameter for tokens returned here.",
+                            "example": "my-org"
+                          },
+                          "group": {
+                            "type": "string",
+                            "description": "The group name. Present only for group-scoped tokens.",
+                            "example": "default"
+                          },
+                          "scopes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "The expanded scope list. Present only for group-scoped tokens.",
+                            "example": ["db:create", "db:configure", "db:mint-token"]
+                          },
+                          "owner": {
+                            "type": "object",
+                            "properties": {
+                              "username": {
+                                "type": "string",
+                                "example": "alice"
+                              },
+                              "email": {
+                                "type": "string",
+                                "example": "alice@example.com"
+                              }
+                            },
+                            "description": "The user who minted the token. Returned to admins and owners so they can see who provisioned each token."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "description": "The date the token was created.",
+                            "example": "2026-05-21"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/organizations/{organizationSlug}/api-tokens/{tokenId}": {
+      "delete": {
+        "summary": "Revoke Organization API Token",
+        "description": "Revokes a token scoped to this organization.\n\nThe path takes a token **ID**, not a name, because names are unique per user but not across users — an admin revoking a member's token can't disambiguate by name alone.\n\nAuthorization is symmetric with the list endpoint:\n\n- **Admins and owners** can revoke any token scoped to the organization (org-scoped or group-scoped, regardless of who minted it).\n- **Members and viewers** can revoke only tokens they minted themselves.\n\nA token scoped to a different organization returns `404`, not `403`, so the endpoint does not leak the existence of cross-org token IDs. Unrestricted tokens are also unreachable here and must be revoked via [`DELETE /v1/auth/api-tokens/{tokenName}`](/api-reference/tokens/revoke).",
+        "operationId": "revokeOrganizationAPIToken",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/organizationSlug"
+          },
+          {
+            "name": "tokenId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the token to revoke (from the list endpoint).",
+            "example": "clGFZ4STEe6fljpFzIum8A"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "The ID of the revoked token.",
+                      "example": "clGFZ4STEe6fljpFzIum8A"
                     }
                   }
                 }
@@ -2432,6 +2580,24 @@
             "type": "string",
             "description": "The organization slug this token is restricted to. Omitted if the token has access to all organizations.",
             "example": "my-org"
+          },
+          "group": {
+            "type": "string",
+            "description": "The group name this token is pinned to. Present only for group-scoped tokens.",
+            "example": "default"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The expanded list of scopes granted to this token. Present only for group-scoped tokens. Presets passed at creation time (`read-only`, `full-access`) are stored as the underlying individual scopes and are returned in that form.",
+            "example": ["db:create", "db:configure", "db:mint-token"]
+          },
+          "created_at": {
+            "type": "string",
+            "description": "The date the token was created, in `YYYY-MM-DD` format.",
+            "example": "2026-05-21"
           }
         }
       },

--- a/api-reference/tokens/create.mdx
+++ b/api-reference/tokens/create.mdx
@@ -9,18 +9,46 @@ The `token` in the response is never revealed again. Store this somewhere safe, 
 
 </Warning>
 
-<RequestExample>
+<Warning>
 
-```bash cURL
-curl -L -X POST https://api.turso.tech/v1/auth/api-tokens/{tokenName} \
-  -H 'Authorization: Bearer TOKEN'
-```
+**Unrestricted (cross-org) tokens are deprecated and will be removed in a future release.** Always include at least `organization` in the request body.
+
+</Warning>
+
+<RequestExample>
 
 ```bash cURL (org-scoped)
 curl -L -X POST https://api.turso.tech/v1/auth/api-tokens/{tokenName} \
   -H 'Authorization: Bearer TOKEN' \
   -H 'Content-Type: application/json' \
   -d '{"organization": "my-org"}'
+```
+
+```bash cURL (deprecated, unrestricted)
+curl -L -X POST https://api.turso.tech/v1/auth/api-tokens/{tokenName} \
+  -H 'Authorization: Bearer TOKEN'
+```
+
+```bash cURL (group-scoped, presets)
+curl -L -X POST https://api.turso.tech/v1/auth/api-tokens/{tokenName} \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "organization": "my-org",
+    "group": "default",
+    "scopes": ["read-only"]
+  }'
+```
+
+```bash cURL (group-scoped, fine-grained)
+curl -L -X POST https://api.turso.tech/v1/auth/api-tokens/{tokenName} \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "organization": "my-org",
+    "group": "default",
+    "scopes": ["db:create", "db:configure", "db:mint-token"]
+  }'
 ```
 
 ```ts Node.js

--- a/api-reference/tokens/list-organization.mdx
+++ b/api-reference/tokens/list-organization.mdx
@@ -1,0 +1,19 @@
+---
+sidebarTitle: List (Organization)
+openapi: "GET /v1/organizations/{organizationSlug}/api-tokens"
+---
+
+<Info>
+
+Use this endpoint to enumerate the tokens that act on a single organization (both org-scoped and group-scoped). Admins and owners see every token in the organization with the minting user attached; members and viewers see only their own. To list tokens across every organization the caller belongs to, use [`GET /v1/auth/api-tokens`](/api-reference/tokens/list) instead.
+
+</Info>
+
+<RequestExample>
+
+```bash cURL
+curl -L 'https://api.turso.tech/v1/organizations/{organizationSlug}/api-tokens' \
+  -H 'Authorization: Bearer TOKEN'
+```
+
+</RequestExample>

--- a/api-reference/tokens/revoke-organization.mdx
+++ b/api-reference/tokens/revoke-organization.mdx
@@ -1,0 +1,19 @@
+---
+sidebarTitle: Revoke (Organization)
+openapi: "DELETE /v1/organizations/{organizationSlug}/api-tokens/{tokenId}"
+---
+
+<Info>
+
+This endpoint takes a token **ID** (not a name) because token names are not unique across users in an organization. Admins and owners may revoke any token scoped to the organization; members and viewers may only revoke tokens they minted themselves. Use [`DELETE /v1/auth/api-tokens/{tokenName}`](/api-reference/tokens/revoke) to revoke unrestricted tokens.
+
+</Info>
+
+<RequestExample>
+
+```bash cURL
+curl -L -X DELETE 'https://api.turso.tech/v1/organizations/{organizationSlug}/api-tokens/{tokenId}' \
+  -H 'Authorization: Bearer TOKEN'
+```
+
+</RequestExample>

--- a/cli/auth/api-tokens/list.mdx
+++ b/cli/auth/api-tokens/list.mdx
@@ -3,8 +3,31 @@ title: auth api-tokens list
 sidebarTitle: list
 ---
 
-To list all API tokens for the current organization, run the following command:
+To list every API token you have minted across every organization you belong to, run the following command:
 
 ```bash
 turso auth api-tokens list
 ```
+
+The output is a table:
+
+```
+NAME            SCOPE                 PERMISSIONS                                CREATED AT
+ci-bot          all                   —                                          2026-04-12
+deploy-bot      my-org                —                                          2026-05-02
+provisioner     my-org/default        read-only                                  2026-05-21
+schema-bot      my-org/default        db:create, db:configure, db:mint-token     2026-05-23
+admin-bot       my-org/default        full-access                                2026-05-24
+```
+
+- **Scope** shows how the token is bound:
+  - `all` — unrestricted, can act on every organization the caller belongs to.
+  - `<org>` — organization-scoped.
+  - `<org>/<group>` — group-scoped.
+- **Permissions** summarizes the scope grant for group-scoped tokens:
+  - `—` for tokens without an explicit scope set (unrestricted and org-scoped tokens).
+  - `read-only` when the only scope is `read`.
+  - `full-access` when every scope is granted.
+  - Otherwise, the comma-separated scope list.
+
+The list always reflects what the platform stores. Presets passed at creation time (`--read-only`, `--full-access`) are expanded into individual scopes before storage and are surfaced here in expanded form.

--- a/cli/auth/api-tokens/mint.mdx
+++ b/cli/auth/api-tokens/mint.mdx
@@ -3,27 +3,83 @@ title: auth api-tokens mint
 sidebarTitle: mint
 ---
 
-To create a new API token, run the following command:
+To create a new API token, scoped to a single organization, run the following command:
 
 ```bash
-turso auth api-tokens mint <api-token-name>
+turso auth api-tokens mint <api-token-name> --org <organization-slug>
 ```
+
+<Warning>
+
+**Unrestricted (cross-org) tokens — minting without `--org` — are deprecated and will be removed in a future release.** Always pass `--org` for new tokens. Existing unrestricted tokens continue to work for now, but you should rotate them to scoped tokens at your earliest convenience.
+
+</Warning>
 
 ## Flags
 
 | Flag | Description |
 | --- | --- |
-| `--org` | Restrict the token to a specific organization |
+| `--org` | Restrict the token to a specific organization. |
+| `--group` | Restrict the token to a specific group inside `--org`. Requires `--org` and at least one scope. |
+| `--scope` | Permission to grant a group-scoped token. Repeatable. |
+| `--read-only` | Shorthand for `--scope read`. |
+| `--full-access` | Shorthand for granting every scope. |
 
-## Organization-Scoped Tokens
+## Organization-scoped tokens
 
-By default, API tokens grant access to all organizations your account belongs to. Use the `--org` flag to create a token that is restricted to a single organization:
+Pass `--org` to restrict a token to a single organization:
 
 ```bash
 turso auth api-tokens mint <api-token-name> --org <organization-slug>
 ```
 
 An org-scoped token can only manage resources (groups, databases, members) within that organization. Requests to any other organization will be rejected.
+
+## Group-scoped tokens
+
+A group-scoped token is pinned to a single group inside an organization and is restricted to an explicit set of operations. It's the right shape for automations that should be able to provision and manage databases inside one group without being able to touch the rest of the organization.
+
+You must be an admin or owner of the organization to mint a group-scoped token.
+
+```bash
+# Read-only access to one group
+turso auth api-tokens mint deploy-bot --org my-org --group default --read-only
+
+# Full access inside one group, but nothing outside it
+turso auth api-tokens mint deploy-bot --org my-org --group default --full-access
+
+# Fine-grained: provision and configure databases, mint SQL tokens
+turso auth api-tokens mint deploy-bot --org my-org --group default \
+  --scope db:create --scope db:configure --scope db:mint-token
+```
+
+### Available scopes
+
+`--scope` can be repeated and accepts any of the following:
+
+| Scope | Allows |
+| --- | --- |
+| `read` | All GET-style routes: list/retrieve databases and groups, configuration, usage, instances, locations. |
+| `db:create` | Create databases inside the group, seed from a dump, restore. |
+| `db:delete` | Delete a database inside the group. |
+| `db:configure` | Patch database configuration, transfer, wake, add or remove instances. |
+| `db:mint-token` | Issue a SQL-engine token or TLS client certificate for a database inside the group. |
+| `db:rotate-creds` | Rotate the database signing key, invalidating every SQL token previously issued for it. |
+| `group:configure` | Configure, rename, update, unarchive the group, or add and remove locations. |
+| `group:mint-token` | Issue a group-level SQL-engine token. |
+| `group:rotate-creds` | Rotate the group signing key, invalidating every SQL token issued against any database in the group. |
+
+<Warning>
+
+`db:mint-token` and `db:rotate-creds` are deliberately separate scopes. Minting a new SQL credential is additive; rotating invalidates every credential currently in use, which can take down running applications. Grant rotation only to automations that need it.
+
+</Warning>
+
+`--scope`, `--read-only`, and `--full-access` are mutually exclusive — pass one flavor at a time. Unknown scope labels are rejected before the request is sent. Group create, group delete, group transfer, and AWS migration are never reachable from a group-scoped token at any scope.
+
+### Lifecycle
+
+Group-scoped tokens are pinned by the group's UUID, not its name. Deleting a group, or transferring it to another organization, cascades a revoke to every token scoped to it. A new group created with the same name does not inherit tokens from the previous one.
 
 <Warning>
   The token value is only shown once at creation time. Store it somewhere safe.

--- a/docs.json
+++ b/docs.json
@@ -624,7 +624,9 @@
                       "api-reference/tokens/create",
                       "api-reference/tokens/validate",
                       "api-reference/tokens/list",
-                      "api-reference/tokens/revoke"
+                      "api-reference/tokens/revoke",
+                      "api-reference/tokens/list-organization",
+                      "api-reference/tokens/revoke-organization"
                     ]
                   }
                 ]


### PR DESCRIPTION
## Summary

- Documents group-scoped Platform API tokens — pinned to one group inside an org, carrying a fixed scope vocabulary (`read`, `db:create`, `db:delete`, `db:configure`, `db:mint-token`, `db:rotate-creds`, `group:configure`, `group:mint-token`, `group:rotate-creds`) plus `read-only` / `full-access` presets. Covers turso-platform PRs [#3755](https://github.com/tursodatabase/turso-platform/pull/3755) and [#3808](https://github.com/tursodatabase/turso-platform/pull/3808), and turso-cli [#1049](https://github.com/tursodatabase/turso-cli/pull/1049).
- Documents the two new org-admin endpoints (`GET` / `DELETE /v1/organizations/{org}/api-tokens`) added in turso-platform [#3818](https://github.com/tursodatabase/turso-platform/pull/3818), including the admin-vs-member visibility split and the ID-not-name revoke shape.
- Marks unrestricted (cross-org) tokens as deprecated and slated for removal in a future release, on both the API reference and the CLI reference.

Per-file:

- `api-reference/openapi.json` — adds `group` + `scopes` to the create-token request body and the `APIToken` schema, and the two new org-admin paths.
- `api-reference/authentication.mdx` — restructured around the three restriction levels with the scope and preset tables, lifecycle notes (UUID pinning, cascade-revoke), and pointers to the org-admin endpoints.
- `api-reference/tokens/create.mdx` — group-scoped cURL examples (preset and fine-grained).
- `api-reference/tokens/list-organization.mdx`, `revoke-organization.mdx` — new openapi-driven reference pages, registered in `docs.json`.
- `cli/auth/api-tokens/mint.mdx` — `--group`, `--scope`, `--read-only`, `--full-access` flags + full group-scoped section.
- `cli/auth/api-tokens/list.mdx` — new `Scope` and `Permissions` columns with an example table.

Dashboard left out by design — dashboard surface has minimal docs coverage by convention.

## Test plan

- [ ] `docs.json` and `api-reference/openapi.json` parse as valid JSON (verified locally).
- [ ] Mintlify preview renders the new openapi-driven pages (`tokens/list-organization`, `tokens/revoke-organization`) and the updated request/response shape on `tokens/create`.
- [ ] Spot-check internal links from `authentication.mdx` to the new reference pages and from `mint.mdx` to the scope tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
