### PR TITLE
docs: database access allow rules

### DIFF
--- a/api-reference/databases/update-configuration.mdx
+++ b/api-reference/databases/update-configuration.mdx
@@ -13,7 +13,9 @@ curl -L -X PATCH 'https://api.turso.tech/v1/organizations/{organizationSlug}/dat
       "size_limit": "500mb",
       "delete_protection": true,
       "block_reads": false,
-      "block_writes": false
+      "block_writes": false,
+      "allowed_ips": ["203.0.113.7", "10.0.0.0/8"],
+      "allowed_aws_vpc_ids": ["vpce-0fe6c8807461bba49"]
   }'
 ```
 

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1953,7 +1953,7 @@
     "/v1/auth/api-tokens/{tokenName}": {
       "post": {
         "summary": "Create API Token",
-        "description": "Returns a new API token belonging to a user.\n\nThe token can be minted at three levels of restriction, in increasing order of narrowness:\n\n- **Organization-scoped** — pass `organization`. The token can only act on resources inside that organization.\n- **Group-scoped** — pass `organization`, `group`, and `scopes`. The token is pinned to a single group inside the organization and only the operations listed in `scopes` are allowed. The caller must be an admin or owner of the organization.\n- **Unrestricted** *(deprecated)* — no request body. The token can act on every organization the caller belongs to. **Unrestricted tokens are deprecated and will be removed in a future release.** Always pass `organization` for new tokens and rotate existing unrestricted tokens to scoped tokens.\n\nGroup-scoped tokens are designed for automations that should be able to provision and manage databases inside a single group without being able to touch the rest of the organization.",
+        "description": "Returns a new API token belonging to a user.\n\nThe token can be minted at three levels of restriction, in increasing order of narrowness:\n\n- **Organization-scoped** \u2014 pass `organization`. The token can only act on resources inside that organization.\n- **Group-scoped** \u2014 pass `organization`, `group`, and `scopes`. The token is pinned to a single group inside the organization and only the operations listed in `scopes` are allowed. The caller must be an admin or owner of the organization.\n- **Unrestricted** *(deprecated)* \u2014 no request body. The token can act on every organization the caller belongs to. **Unrestricted tokens are deprecated and will be removed in a future release.** Always pass `organization` for new tokens and rotate existing unrestricted tokens to scoped tokens.\n\nGroup-scoped tokens are designed for automations that should be able to provision and manage databases inside a single group without being able to touch the rest of the organization.",
         "operationId": "createAPIToken",
         "parameters": [
           {
@@ -1996,8 +1996,12 @@
                         "full-access"
                       ]
                     },
-                    "description": "Permissions to grant a group-scoped token. Each entry is either an individual scope or one of the presets `read-only` (expands to `read`) and `full-access` (expands to every scope). Required and must be non-empty when `group` is set. `db:mint-token` lets the token issue new SQL credentials; `db:rotate-creds` invalidates every existing SQL token for the database — they are deliberately separate because rotation is destructive.",
-                    "example": ["db:create", "db:configure", "db:mint-token"]
+                    "description": "Permissions to grant a group-scoped token. Each entry is either an individual scope or one of the presets `read-only` (expands to `read`) and `full-access` (expands to every scope). Required and must be non-empty when `group` is set. `db:mint-token` lets the token issue new SQL credentials; `db:rotate-creds` invalidates every existing SQL token for the database \u2014 they are deliberately separate because rotation is destructive.",
+                    "example": [
+                      "db:create",
+                      "db:configure",
+                      "db:mint-token"
+                    ]
                   }
                 }
               }
@@ -2061,7 +2065,7 @@
     "/v1/organizations/{organizationSlug}/api-tokens": {
       "get": {
         "summary": "List Organization API Tokens",
-        "description": "Returns the API tokens scoped to this organization (both organization-scoped and group-scoped). Unrestricted tokens are not returned here — manage those via [`GET /v1/auth/api-tokens`](/api-reference/tokens/list).\n\nAuthorization is symmetric with the revoke endpoint:\n\n- **Admins and owners** see every token scoped to the organization, with the minting user attached in the `owner` field.\n- **Members and viewers** see only tokens they minted themselves.\n\nThis mirrors the personal-access-token model used in GitHub organization settings: admins get the full attribution list; everyone else sees their own access.",
+        "description": "Returns the API tokens scoped to this organization (both organization-scoped and group-scoped). Unrestricted tokens are not returned here \u2014 manage those via [`GET /v1/auth/api-tokens`](/api-reference/tokens/list).\n\nAuthorization is symmetric with the revoke endpoint:\n\n- **Admins and owners** see every token scoped to the organization, with the minting user attached in the `owner` field.\n- **Members and viewers** see only tokens they minted themselves.\n\nThis mirrors the personal-access-token model used in GitHub organization settings: admins get the full attribution list; everyone else sees their own access.",
         "operationId": "listOrganizationAPITokens",
         "parameters": [
           {
@@ -2107,7 +2111,11 @@
                               "type": "string"
                             },
                             "description": "The expanded scope list. Present only for group-scoped tokens.",
-                            "example": ["db:create", "db:configure", "db:mint-token"]
+                            "example": [
+                              "db:create",
+                              "db:configure",
+                              "db:mint-token"
+                            ]
                           },
                           "owner": {
                             "type": "object",
@@ -2142,7 +2150,7 @@
     "/v1/organizations/{organizationSlug}/api-tokens/{tokenId}": {
       "delete": {
         "summary": "Revoke Organization API Token",
-        "description": "Revokes a token scoped to this organization.\n\nThe path takes a token **ID**, not a name, because names are unique per user but not across users — an admin revoking a member's token can't disambiguate by name alone.\n\nAuthorization is symmetric with the list endpoint:\n\n- **Admins and owners** can revoke any token scoped to the organization (org-scoped or group-scoped, regardless of who minted it).\n- **Members and viewers** can revoke only tokens they minted themselves.\n\nA token scoped to a different organization returns `404`, not `403`, so the endpoint does not leak the existence of cross-org token IDs. Unrestricted tokens are also unreachable here and must be revoked via [`DELETE /v1/auth/api-tokens/{tokenName}`](/api-reference/tokens/revoke).",
+        "description": "Revokes a token scoped to this organization.\n\nThe path takes a token **ID**, not a name, because names are unique per user but not across users \u2014 an admin revoking a member's token can't disambiguate by name alone.\n\nAuthorization is symmetric with the list endpoint:\n\n- **Admins and owners** can revoke any token scoped to the organization (org-scoped or group-scoped, regardless of who minted it).\n- **Members and viewers** can revoke only tokens they minted themselves.\n\nA token scoped to a different organization returns `404`, not `403`, so the endpoint does not leak the existence of cross-org token IDs. Unrestricted tokens are also unreachable here and must be revoked via [`DELETE /v1/auth/api-tokens/{tokenName}`](/api-reference/tokens/revoke).",
         "operationId": "revokeOrganizationAPIToken",
         "parameters": [
           {
@@ -2592,7 +2600,11 @@
               "type": "string"
             },
             "description": "The expanded list of scopes granted to this token. Present only for group-scoped tokens. Presets passed at creation time (`read-only`, `full-access`) are stored as the underlying individual scopes and are returned in that form.",
-            "example": ["db:create", "db:configure", "db:mint-token"]
+            "example": [
+              "db:create",
+              "db:configure",
+              "db:mint-token"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -3007,6 +3019,27 @@
             "type": "boolean",
             "description": "Prevent the database from being deleted.",
             "example": true
+          },
+          "allowed_ips": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of allowed IP addresses and CIDR blocks. Only connections from these sources are accepted. Pass an empty array to clear the list. Omit to leave unchanged.",
+            "example": [
+              "203.0.113.7",
+              "10.0.0.0/8"
+            ]
+          },
+          "allowed_aws_vpc_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of allowed AWS VPC endpoint IDs (vpce-...). Only connections arriving through these endpoints are accepted. Pass an empty array to clear the list. Omit to leave unchanged.",
+            "example": [
+              "vpce-0fe6c8807461bba49"
+            ]
           }
         }
       },
@@ -3038,6 +3071,27 @@
             "type": "boolean",
             "description": "Prevent the database from being deleted.",
             "example": true
+          },
+          "allowed_ips": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of allowed IP addresses and CIDR blocks. Empty means no IP restriction.",
+            "example": [
+              "203.0.113.7",
+              "10.0.0.0/8"
+            ]
+          },
+          "allowed_aws_vpc_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of allowed AWS VPC endpoint IDs. Empty means no VPC endpoint restriction.",
+            "example": [
+              "vpce-0fe6c8807461bba49"
+            ]
           }
         }
       },

--- a/cli/db/config/allow-rules/clear.mdx
+++ b/cli/db/config/allow-rules/clear.mdx
@@ -1,0 +1,39 @@
+---
+title: db config allow-rules clear
+sidebarTitle: clear
+---
+
+Clear the access allow rules for a database, allowing connections from any source.
+
+```bash
+turso db config allow-rules clear <database-name> [flags]
+```
+
+Without any flags, both the IP list and the AWS VPC endpoint list are cleared. Use `--ips` or `--aws-vpcs` to clear only one list.
+
+## Flags
+
+| Flag        | Description                                    |
+| ----------- | ---------------------------------------------- |
+| `--ips`     | Clear only the list of allowed IPs.            |
+| `--aws-vpcs`| Clear only the list of allowed AWS VPC endpoint IDs. |
+
+## Examples
+
+### Clear all rules
+
+```bash
+turso db config allow-rules clear my-db
+```
+
+### Clear only the IP list
+
+```bash
+turso db config allow-rules clear my-db --ips
+```
+
+### Clear only the VPC list
+
+```bash
+turso db config allow-rules clear my-db --aws-vpcs
+```

--- a/cli/db/config/allow-rules/set.mdx
+++ b/cli/db/config/allow-rules/set.mdx
@@ -1,0 +1,55 @@
+---
+title: db config allow-rules set
+sidebarTitle: set
+---
+
+Set the access allow rules for a database. Each flag replaces the corresponding list; a list whose flag is not provided is left unchanged.
+
+```bash
+turso db config allow-rules set <database-name> [--ip <address-or-cidr>]... [--aws-vpc <vpce-id>]...
+```
+
+At least one of `--ip` or `--aws-vpc` must be provided. To remove restrictions use [`turso db config allow-rules clear`](/cli/db/config/allow-rules/clear).
+
+## Flags
+
+| Flag        | Description                                                                          |
+| ----------- | ------------------------------------------------------------------------------------ |
+| `--ip`      | IP address or CIDR block to allow. Repeatable. Replaces the current IP list.        |
+| `--aws-vpc` | AWS VPC endpoint ID (`vpce-...`) to allow. Repeatable. Replaces the current VPC list. |
+
+## Examples
+
+### Allow a single IP
+
+```bash
+turso db config allow-rules set my-db --ip 203.0.113.7
+```
+
+### Allow a CIDR range
+
+```bash
+turso db config allow-rules set my-db --ip 10.0.0.0/8
+```
+
+### Allow multiple IPs
+
+```bash
+turso db config allow-rules set my-db --ip 203.0.113.7 --ip 10.0.0.0/8
+```
+
+### Restrict to an AWS VPC endpoint
+
+```bash
+turso db config allow-rules set my-db --aws-vpc vpce-0fe6c8807461bba49
+```
+
+### Combine IP and VPC rules
+
+When both lists are set, connections must satisfy both constraints.
+
+```bash
+turso db config allow-rules set my-db \
+  --ip 10.0.0.0/8 \
+  --aws-vpc vpce-0fe6c8807461bba49
+```

--- a/cli/db/config/allow-rules/show.mdx
+++ b/cli/db/config/allow-rules/show.mdx
@@ -1,0 +1,26 @@
+---
+title: db config allow-rules show
+sidebarTitle: show
+---
+
+Print the access allow rules for a database.
+
+```bash
+turso db config allow-rules show <database-name>
+```
+
+When no rules are configured, all connections are accepted and the command reports:
+
+```
+Access allow rules are empty: connections from any source are accepted
+```
+
+When rules are set, each list is printed:
+
+```
+Allowed IPs:
+  203.0.113.7
+  10.0.0.0/8
+Allowed AWS VPC endpoint IDs:
+  vpce-0fe6c8807461bba49
+```

--- a/cloud/allow-rules.mdx
+++ b/cloud/allow-rules.mdx
@@ -1,0 +1,120 @@
+---
+title: Database Access Allow Rules
+description: Restrict database access to specific IP addresses, CIDR ranges, or AWS VPC endpoints.
+---
+
+Allow rules let you lock down a database so that only connections from specific sources are accepted. You can restrict by IP address or CIDR range, by AWS VPC endpoint ID, or both at the same time.
+
+<Info>
+  **AND semantics.** When both lists are configured, a connection must satisfy **both** rules: the client IP must be on the allowed-IP list **and** the connection must arrive through one of the allowed VPC endpoints.
+</Info>
+
+## Show Current Rules
+
+```bash
+turso db config allow-rules show <database-name>
+```
+
+If no rules are configured, all connections are accepted:
+
+```
+Access allow rules are empty: connections from any source are accepted
+```
+
+When rules are set, the command prints each list:
+
+```
+Allowed IPs:
+  203.0.113.7
+  10.0.0.0/8
+Allowed AWS VPC endpoint IDs:
+  vpce-0fe6c8807461bba49
+```
+
+## Restrict by IP Address or CIDR
+
+Use `--ip` (repeatable) to set the list of allowed IP addresses and CIDR blocks. The flag **replaces** the current list each time it is used.
+
+```bash
+# Allow a single IP
+turso db config allow-rules set my-db --ip 203.0.113.7
+
+# Allow a CIDR range
+turso db config allow-rules set my-db --ip 10.0.0.0/8
+
+# Allow multiple entries at once
+turso db config allow-rules set my-db --ip 203.0.113.7 --ip 10.0.0.0/8
+```
+
+Both IPv4 and IPv6 addresses are accepted. CIDR notation (e.g. `10.0.0.0/8`) is supported for ranges.
+
+## Restrict by AWS VPC Endpoint
+
+Use `--aws-vpc` (repeatable) to set the list of allowed [AWS VPC endpoint IDs](/cloud/private-endpoints). IDs must start with `vpce-`.
+
+```bash
+turso db config allow-rules set my-db --aws-vpc vpce-0fe6c8807461bba49
+```
+
+## Combine IP and VPC Rules
+
+You can set both lists in a single command. Connections must satisfy both constraints.
+
+```bash
+turso db config allow-rules set my-db \
+  --ip 10.0.0.0/8 \
+  --aws-vpc vpce-0fe6c8807461bba49
+```
+
+A later call that only specifies `--ip` leaves the VPC list unchanged, and vice versa:
+
+```bash
+# Add a new IP without touching the VPC list
+turso db config allow-rules set my-db --ip 198.51.100.5
+```
+
+## Clear Rules
+
+Remove all allow rules to allow connections from any source:
+
+```bash
+turso db config allow-rules clear my-db
+```
+
+Clear only one list while leaving the other intact:
+
+```bash
+# Clear only the IP list
+turso db config allow-rules clear my-db --ips
+
+# Clear only the VPC list
+turso db config allow-rules clear my-db --aws-vpcs
+```
+
+## API
+
+Allow rules are managed through the database [configuration endpoint](/api-reference/databases/update-configuration). Set `allowed_ips` and/or `allowed_aws_vpc_ids` in the request body:
+
+```bash
+curl -L -X PATCH 'https://api.turso.tech/v1/organizations/{organizationSlug}/databases/{databaseName}/configuration' \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "allowed_ips": ["203.0.113.7", "10.0.0.0/8"],
+    "allowed_aws_vpc_ids": ["vpce-0fe6c8807461bba49"]
+  }'
+```
+
+Pass an explicit empty array to clear a list:
+
+```bash
+curl -L -X PATCH 'https://api.turso.tech/v1/organizations/{organizationSlug}/databases/{databaseName}/configuration' \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "allowed_ips": [],
+    "allowed_aws_vpc_ids": []
+  }'
+```
+
+Omitting a field from the request body leaves that list unchanged.

--- a/docs.json
+++ b/docs.json
@@ -174,6 +174,7 @@
               "cloud/migrate-to-turso",
               "cloud/durability",
               "cloud/private-endpoints",
+              "cloud/allow-rules",
               "cloud/encryption",
               "help/usage-and-billing",
               "features/ai-and-embeddings",
@@ -454,6 +455,14 @@
                         "pages": [
                           "cli/db/tokens/create",
                           "cli/db/tokens/invalidate"
+                        ]
+                      },
+                      {
+                        "group": "config allow-rules",
+                        "pages": [
+                          "cli/db/config/allow-rules/show",
+                          "cli/db/config/allow-rules/set",
+                          "cli/db/config/allow-rules/clear"
                         ]
                       }
                     ]


### PR DESCRIPTION
## Summary

- Adds `cloud/allow-rules.mdx` — feature page under Turso Cloud covering IP/CIDR and AWS VPC endpoint allow rules, with CLI and API examples
- Adds CLI reference pages for `turso db config allow-rules show/set/clear`
- Extends the OpenAPI schema with `allowed_ips` and `allowed_aws_vpc_ids` on both the input and response for the database configuration endpoint
- Updates the `update-configuration.mdx` cURL example to include the new fields
- Wires everything into `docs.json`

## Test plan

- [ ] Verify `cloud/allow-rules` renders correctly in the sidebar (after `private-endpoints`)
- [ ] Verify CLI reference pages appear under `db > config allow-rules`
- [ ] Confirm the API reference picks up the new schema fields on the configuration endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)