### PR TITLE
docs: add Codex install tab to the MCP integration page

### DIFF
--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -42,6 +42,22 @@ apart and confirm before doing anything that changes data.
   to approve access (see [Authorize](#authorize-access) below).
 
   </Tab>
+  <Tab title="Codex">
+
+  Install the plugin (it bundles the Turso skill too), then authenticate:
+
+  ```bash
+  codex plugin marketplace add tursodatabase/turso-mcp
+  codex plugin add turso@turso
+  codex mcp login turso
+  ```
+
+  A browser opens to approve access (see [Authorize](#authorize-access) below).
+  MCP-only alternative: add `[mcp_servers.turso]` with
+  `url = "https://mcp.turso.ai/mcp"` to `~/.codex/config.toml`, then
+  `codex mcp login turso`.
+
+  </Tab>
   <Tab title="Claude (web & desktop)">
 
   Add a custom connector pointing at the Turso MCP server:


### PR DESCRIPTION
Adds a **Codex** tab to the Connect section of `integrations/mcp` (alongside Claude Code), covering `codex plugin marketplace add` / `codex plugin add turso@turso` / `codex mcp login turso`, plus the config.toml MCP-only alternative. Follow-up to the merged MCP page (#398).

🤖 Generated with [Claude Code](https://claude.com/claude-code)