### PR TITLE
fix: import name for Prisma adapter in documentation

### DIFF
--- a/sdk/ts/orm/prisma.mdx
+++ b/sdk/ts/orm/prisma.mdx
@@ -80,9 +80,9 @@ pnpm dlx prisma generate
 
 ```ts Node.js / Serverless
 import { PrismaClient } from "@prisma/client";
-import { PrismaLibSQL } from "@prisma/adapter-libsql";
+import { PrismaLibSql } from "@prisma/adapter-libsql";
 
-const adapter = new PrismaLibSQL({
+const adapter = new PrismaLibSql({
   url: process.env.TURSO_DATABASE_URL,
   authToken: process.env.TURSO_AUTH_TOKEN,
 })
@@ -91,9 +91,9 @@ const prisma = new PrismaClient({ adapter })
 
 ```ts Edge Runtimes
 import { PrismaClient } from "@prisma/client";
-import { PrismaLibSQL } from "@prisma/adapter-libsql";
+import { PrismaLibSql } from "@prisma/adapter-libsql";
 
-const adapter = new PrismaLibSQL({
+const adapter = new PrismaLibSql({
   url: process.env.TURSO_DATABASE_URL,
   authToken: process.env.TURSO_AUTH_TOKEN,
 })


### PR DESCRIPTION
Ref: https://github.com/prisma/prisma/tree/main/packages/adapter-libsql