### PR TITLE
Add Rust code examples to sync usage documentation

### DIFF
--- a/sync/checkpoint.mdx
+++ b/sync/checkpoint.mdx
@@ -51,6 +51,16 @@ after, _ := db.Stats(ctx)
 log.Printf("WAL size after: %d", after.MainWalSize)
 ```
 
+```rs Rust
+let before = db.stats().await?;
+println!("WAL size before: {}", before.main_wal_size);
+
+db.checkpoint().await?;
+
+let after = db.stats().await?;
+println!("WAL size after: {}", after.main_wal_size);
+```
+
 </CodeGroup>
 
 
@@ -76,6 +86,10 @@ conn.checkpoint()
 if err := db.Checkpoint(ctx); err != nil {
 	return err
 }
+```
+
+```rs Rust
+db.checkpoint().await?;
 ```
 
 </CodeGroup>

--- a/sync/local-sync-server.mdx
+++ b/sync/local-sync-server.mdx
@@ -56,6 +56,16 @@ db, err := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{
 })
 ```
 
+```rs Rust
+use turso::sync::Builder;
+
+let db = Builder::new_remote("./local-replica.db")
+  .with_remote_url("http://localhost:8080")
+  .build()
+  .await?;
+
+```
+
 </CodeGroup>
 
 Once connected, all sync operations (`push`, `pull`, `checkpoint`, `stats`) work exactly as described in the [Usage](/sync/usage) guide.
@@ -126,6 +136,22 @@ connA.ExecContext(ctx, "INSERT INTO notes VALUES ('n1', 'hello from client A')")
 clientA.Push(ctx)
 ```
 
+```rs Rust
+use turso::sync::Builder;
+
+let client_a = Builder::new_remote("./client-a.db")
+  .with_remote_url("http://localhost:8080")
+  .build()
+  .await?;
+
+let conn_a = client_a.connect().await?;
+
+conn_a.execute("CREATE TABLE IF NOT EXISTS notes(id TEXT PRIMARY KEY, body TEXT)").await?;
+conn_a.execute("INSERT INTO notes VALUES ( ?, ? )", ( "n1", "hello from client A" )).await?;
+
+client_a.push().await?;
+```
+
 </CodeGroup>
 
 </Step>
@@ -180,6 +206,21 @@ log.Println("changes pulled:", changed)
 
 connB, _ := clientB.Connect(ctx)
 rows, _ := connB.QueryContext(ctx, "SELECT * FROM notes")
+```
+
+```rs Rust
+use turso::sync::Builder;
+
+let client_b = Builder::new_remote("./client-b.db")
+  .with_remote_url("http://localhost:8080")
+  .build()
+  .await?;
+
+let changed = client_b.pull().await?;
+println!("changes pulled: {}", changed);
+
+let conn_b = client_b.connect().await?;
+let rows = conn_b.query("SELECT * FROM notes", ()).await?;
 ```
 
 </CodeGroup>

--- a/sync/partial.mdx
+++ b/sync/partial.mdx
@@ -80,6 +80,21 @@ db, err := turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
 })
 ```
 
+```rs Rust
+use turso::sync::{Builder, PartialBootstrapStrategy, PartialSyncOpts};
+
+let db = Builder::new_remote("./app.db")
+ .with_remote_url("libsql://...")
+ .with_auth_token(&std::env::var("TURSO_AUTH_TOKEN")?)
+ .with_partial_sync_opts_experimental(PartialSyncOpts {
+   bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix { length: 128 * 1024 /* 128 KiB */ }),
+    segment_size: 0,
+    prefetch: false,
+ })
+ .build()
+ .await?;
+```
+
 </CodeGroup>
 
 ### Query bootstrap
@@ -129,6 +144,23 @@ db, err := turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
     BoostrapStrategyQuery: "SELECT * FROM messages WHERE user_id = 'u_123' LIMIT 100",
   },
 })
+```
+
+```rs Rust
+use turso::sync::{Builder, PartialBootstrapStrategy, PartialSyncOpts};
+
+let db = Builder::new_remote("./app.db")
+ .with_remote_url("libsql://...")
+ .with_auth_token(&std::env::var("TURSO_AUTH_TOKEN")?)
+ .with_partial_sync_opts_experimental(PartialSyncOpts {
+   bootstrap_strategy: Some(PartialBootstrapStrategy::Query {
+    query: String::from("SELECT * FROM messages WHERE user_id = 'u_123' LIMIT 100"),
+   }),
+   segment_size: 0,
+   prefetch: false,
+ })
+ .build()
+ .await?;
 ```
 
 </CodeGroup>
@@ -307,6 +339,18 @@ turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
 })
 ```
 
+```rs Rust
+let db = Builder::new_remote("./app.db")
+ ...
+ .with_partial_sync_opts_experimental(PartialSyncOpts {
+   bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix { length: 128 * 1024 /* 128 KiB */ }),
+    segment_size: 16 * 1024,
+    prefetch: false,
+ })
+ .build()
+ .await?;
+```
+
 </CodeGroup>
 
 ### Prefetch
@@ -447,6 +491,18 @@ turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
     Prefetch: true,
   },
 })
+```
+
+```rs Rust
+let db = Builder::new_remote("./app.db")
+ ...
+ .with_partial_sync_opts_experimental(PartialSyncOpts {
+   bootstrap_strategy: Some(PartialBootstrapStrategy::Prefix { length: 128 * 1024 /* 128 KiB */ }),
+    segment_size: 0, // defaults to 128 KiB
+    prefetch: true,
+ })
+ .build()
+ .await?;
 ```
 
 </CodeGroup>

--- a/sync/usage.mdx
+++ b/sync/usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Usage
-description: How to enable and use sync with Turso across TypeScript, Python, and Go.
+description: How to enable and use sync with Turso across TypeScript, Python, Go and Rust.
 ---
 
 This guide shows how to set up a Turso database and use the sync features from your application.
@@ -77,6 +77,18 @@ db, err := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{
 })
 ```
 
+```rs Rust
+use turso::sync::Builder;
+
+let db = Builder::new_remote("./app.db")                                // local path
+  .with_remote_url("libsql://...")                                      // remote URL (generated with turso db show <db-name> --url)
+  .with_auth_token(&std::env::var("TURSO_AUTH_TOKEN")?)                 // authentication token (generated with turso db tokens create <db-name>)
+   // .with_long_poll_timeout(std::time::Duration::from_millis(10_000)) // optional: server waits before replying to pull
+   // .bootstrap_if_empty(false)                                        // set to false to avoid bootstrapping on first run
+  .build()
+  .await?;
+```
+
 </CodeGroup>
 
 <Note>
@@ -131,6 +143,21 @@ if err := db.Push(ctx); err != nil {
 }
 ```
 
+```rs Rust
+// create connection instance
+let conn = db.connect().await?;
+
+conn
+  .execute("CREATE TABLE IF NOT EXISTS notes(id TEXT PRIMARY KEY, body TEXT)")
+  .await?;
+
+conn
+  .execute("INSERT INTO notes VALUES ( ?, ? )", ( "n1", "hello" ))
+  .await?;
+
+db.push().await?;
+```
+
 </CodeGroup>
 </Step>
 
@@ -138,7 +165,7 @@ if err := db.Push(ctx); err != nil {
 
 Pull fetches remote changes and applies them locally. It returns a boolean indicating whether anything changed.
 
-- Configure `long_poll_timeout_ms`/`LongPollTimeoutMs` if you want the server to wait for changes and avoid empty replies.
+- Configure `long_poll_timeout_ms`/`LongPollTimeoutMs`/`with_long_poll_timeout` if you want the server to wait for changes and avoid empty replies.
 - If you pushed earlier, a subsequent pull can still return that something changed due to server-side conflict resolution frames.
 
 <CodeGroup>
@@ -162,6 +189,13 @@ if err != nil {
 log.Println("pulled changes:", changed)
 ```
 
+```rs Rust
+// returns true if anything changed locally
+let changed = db.pull().await?;
+
+println!("pulled changes: {}", changed);
+```
+
 </CodeGroup>
 </Step>
 
@@ -183,6 +217,10 @@ conn.checkpoint()
 if err := db.Checkpoint(ctx); err != nil {
 	return err
 }
+```
+
+```rs Rust
+db.checkpoint().await?;
 ```
 
 </CodeGroup>
@@ -237,6 +275,21 @@ log.Printf("stats: cdc=%v, main=%d revert=%d rx=%d tx=%d pull=%d push=%d revisio
   s.LastPushUnixTime,
   s.Revision,
 )
+```
+
+```rs Rust
+let stats = db.stats().await?;
+
+println!("stats: cdc={} main={} revert={} rx={} tx={} pull={:?} push={:?} revision={:?}",
+  stats.cdc_operations,
+  stats.main_wal_size,
+  stats.revert_wal_size,
+  stats.network_received_bytes,
+  stats.network_sent_bytes,
+  stats.last_pull_unix_time,
+  stats.last_push_unix_time,
+  stats.revision,
+);
 ```
 
 </CodeGroup>
@@ -340,6 +393,34 @@ if _, err := db.Pull(ctx); err != nil {
 
 // On a timer or connectivity event
 syncWhenOnline(ctx, db)
+```
+
+```rs Rust
+use turso::sync::{Builder, Database};
+
+// bootstrap_if_empty(false) lets the app start offline without
+// needing to reach the remote on first launch
+let db = Builder::new_remote("./local.db")
+ .with_remote_url(&std::env::var("TURSO_URL")?)
+ .with_auth_token(&std::env::var("TURSO_AUTH_TOKEN")?)
+ .bootstrap_if_empty(false)
+ .build()
+ .await?;
+
+async fn sync_when_online(db: &Database) {
+ if let Err(_) = db.push().await {
+  // No connectivity — changes are safe in the local file
+  // and will sync on the next push() call
+ };
+}
+
+// On app launch, pull the latest state if online
+if let Err(_) = db.pull().await {
+ // Offline — local data is still available for reads and writes
+};
+
+// On a timer or connectivity event
+sync_when_online(&db).await;
 ```
 
 </CodeGroup>


### PR DESCRIPTION
This pull request adds comprehensive Rust code examples to the sync documentation, covering usage, local sync server, checkpointing and partial sync scenarios. The new Rust snippets illustrate how to use the Turso sync client in Rust, mirroring the existing examples for other languages. This improves the developer experience for Rust users like myself and others and ensures parity across language guides.

**The following files were updated:**

* `sync/usage.mdx`:
  - Added Rust code snippets for database setup, pushing and pulling changes, checkpointing, stats retrieval and offline-first usage patterns. 
  - Updated the description to mention Rust support.

* `sync/checkpoint.mdx`:
  - Added Rust code examples for checking WAL size before and after checkpointing, and for performing a checkpoint.

* `sync/local-sync-server.mdx`:
  - Added Rust code snippets for setting up a local sync server, pushing changes from one client and pulling changes from another.
  
* `sync/partial.mdx`:
  - Added Rust examples for partial sync using prefix and query bootstrap strategies, segment size and prefetch options.