### PR TITLE
docs: Turso on Turso Cloud — clarify libSQL vs Turso across the docs

### DIFF
--- a/_snippets/retrieve-database-credentials-tursodb.mdx
+++ b/_snippets/retrieve-database-credentials-tursodb.mdx
@@ -1,0 +1,24 @@
+Get the database URL:
+
+```bash
+turso db show --url <database-name>
+```
+
+Get the database authentication token:
+
+```bash
+turso db tokens create <database-name>
+```
+
+Assign credentials to the environment variables inside `.env`.
+
+```bash
+TURSO_DATABASE_URL=turso://[databaseName]-[organizationSlug].turso.io
+TURSO_AUTH_TOKEN=
+```
+
+<Info>
+  Turso databases accept both the `turso://` and `libsql://` URL schemes. We
+  recommend `turso://` to make it clear the database runs on the Turso engine —
+  if the CLI prints a `libsql://` URL, you can use it as is or swap the scheme.
+</Info>

--- a/_snippets/retrieve-database-credentials-tursodb.mdx
+++ b/_snippets/retrieve-database-credentials-tursodb.mdx
@@ -16,9 +16,3 @@ Assign credentials to the environment variables inside `.env`.
 TURSO_DATABASE_URL=turso://[databaseName]-[organizationSlug].turso.io
 TURSO_AUTH_TOKEN=
 ```
-
-<Info>
-  Turso databases accept both the `turso://` and `libsql://` URL schemes. We
-  recommend `turso://` to make it clear the database runs on the Turso engine —
-  if the CLI prints a `libsql://` URL, you can use it as is or swap the scheme.
-</Info>

--- a/agentfs/guides/sync.mdx
+++ b/agentfs/guides/sync.mdx
@@ -15,14 +15,14 @@ If you don't have a Turso account, [sign up](https://turso.tech) first.
 Create a database for your agent:
 
 ```bash
-turso db create my-agent-db
+turso db create my-agent-db --tursodb
 ```
 
 Get the database URL:
 
 ```bash
 turso db show my-agent-db --url
-# Output: libsql://my-agent-db-username.turso.io
+# Output: turso://my-agent-db-username.turso.io
 ```
 
 ### 2. Initialize with Sync
@@ -30,7 +30,7 @@ turso db show my-agent-db --url
 Create a new agent filesystem with sync enabled:
 
 ```bash
-agentfs init my-agent --sync-remote-url libsql://my-agent-db-username.turso.io
+agentfs init my-agent --sync-remote-url turso://my-agent-db-username.turso.io
 ```
 
 Or add sync to an existing agent:
@@ -85,7 +85,7 @@ Automatically back up agent state:
 agentfs sync my-agent push
 
 # On a new machine
-agentfs init my-agent --sync-remote-url libsql://...
+agentfs init my-agent --sync-remote-url turso://...
 agentfs sync my-agent pull
 ```
 
@@ -109,7 +109,7 @@ For large filesystems, use partial sync to only fetch what's needed:
 
 ```bash
 agentfs init my-agent \
-  --sync-remote-url libsql://... \
+  --sync-remote-url turso://... \
   --sync-partial-prefetch \
   --sync-partial-segment-size 1000
 ```

--- a/agentfs/guides/sync.mdx
+++ b/agentfs/guides/sync.mdx
@@ -15,14 +15,14 @@ If you don't have a Turso account, [sign up](https://turso.tech) first.
 Create a database for your agent:
 
 ```bash
-turso db create my-agent-db --tursodb
+turso db create my-agent-db
 ```
 
 Get the database URL:
 
 ```bash
 turso db show my-agent-db --url
-# Output: turso://my-agent-db-username.turso.io
+# Output: libsql://my-agent-db-username.turso.io
 ```
 
 ### 2. Initialize with Sync
@@ -30,7 +30,7 @@ turso db show my-agent-db --url
 Create a new agent filesystem with sync enabled:
 
 ```bash
-agentfs init my-agent --sync-remote-url turso://my-agent-db-username.turso.io
+agentfs init my-agent --sync-remote-url libsql://my-agent-db-username.turso.io
 ```
 
 Or add sync to an existing agent:
@@ -85,7 +85,7 @@ Automatically back up agent state:
 agentfs sync my-agent push
 
 # On a new machine
-agentfs init my-agent --sync-remote-url turso://...
+agentfs init my-agent --sync-remote-url libsql://...
 agentfs sync my-agent pull
 ```
 
@@ -109,7 +109,7 @@ For large filesystems, use partial sync to only fetch what's needed:
 
 ```bash
 agentfs init my-agent \
-  --sync-remote-url turso://... \
+  --sync-remote-url libsql://... \
   --sync-partial-prefetch \
   --sync-partial-segment-size 1000
 ```

--- a/docs.json
+++ b/docs.json
@@ -38,7 +38,7 @@
     },
     "tabs": [
       {
-        "tab": "Turso Database (beta)",
+        "tab": "Turso Database",
         "groups": [
           {
             "group": "Getting Started",

--- a/integrations/agentic-stripe.mdx
+++ b/integrations/agentic-stripe.mdx
@@ -156,18 +156,15 @@ const conn = connect({
   authToken: process.env.MY_DB_AUTH_TOKEN,
 });
 
-// Execute a query — prepare() is async, await it before using the statement
-const stmt = await conn.prepare("SELECT * FROM users WHERE active = ?");
-const result = await stmt.all([1]);
+// Execute a query
+const result = await conn.prepare("SELECT * FROM users WHERE active = ?").all([1]);
 console.log(result);
 
 // Positional parameters
-const byId = await conn.prepare("SELECT * FROM users WHERE id = ?");
-const row = await byId.get([1]);
+await conn.prepare("SELECT * FROM users WHERE id = ?").get([1]);
 
 // Named parameters
-const insert = await conn.prepare("INSERT INTO users VALUES (:name)");
-await insert.run({ name: "Alice" });
+await conn.prepare("INSERT INTO users VALUES (:name)").run({ name: "Alice" });
 
 // Batch multiple statements in an implicit transaction
 await conn.batch([
@@ -176,14 +173,10 @@ await conn.batch([
   "INSERT INTO todos (title) VALUES ('Write code')",
 ]);
 
-// Transactions: wrap statements in a function; each call runs in BEGIN..COMMIT
-const addTodo = await conn.prepare("INSERT INTO todos (title) VALUES (?)");
-const addMany = conn.transaction((titles) => {
-  for (const title of titles) {
-    addTodo.run([title]);
-  }
-});
-await addMany(["Ship docs", "Review PR"]);
+// Interactive transaction
+const tx = await conn.transaction("write");
+await tx.prepare("UPDATE accounts SET balance = balance - ? WHERE id = ?").run([100, 1]);
+await tx.prepare("UPDATE accounts SET balance = balance + ? WHERE id = ?").run([100, 2]);
 await tx.commit();
 ```
 

--- a/integrations/agentic-stripe.mdx
+++ b/integrations/agentic-stripe.mdx
@@ -156,15 +156,18 @@ const conn = connect({
   authToken: process.env.MY_DB_AUTH_TOKEN,
 });
 
-// Execute a query
-const result = await conn.prepare("SELECT * FROM users WHERE active = ?").all([1]);
+// Execute a query — prepare() is async, await it before using the statement
+const stmt = await conn.prepare("SELECT * FROM users WHERE active = ?");
+const result = await stmt.all([1]);
 console.log(result);
 
 // Positional parameters
-await conn.prepare("SELECT * FROM users WHERE id = ?").get([1]);
+const byId = await conn.prepare("SELECT * FROM users WHERE id = ?");
+const row = await byId.get([1]);
 
 // Named parameters
-await conn.prepare("INSERT INTO users VALUES (:name)").run({ name: "Alice" });
+const insert = await conn.prepare("INSERT INTO users VALUES (:name)");
+await insert.run({ name: "Alice" });
 
 // Batch multiple statements in an implicit transaction
 await conn.batch([
@@ -173,11 +176,14 @@ await conn.batch([
   "INSERT INTO todos (title) VALUES ('Write code')",
 ]);
 
-// Interactive transaction
-const tx = await conn.transaction("write");
-await tx.prepare("UPDATE accounts SET balance = balance - ? WHERE id = ?").run([100, 1]);
-await tx.prepare("UPDATE accounts SET balance = balance + ? WHERE id = ?").run([100, 2]);
-await tx.commit();
+// Transactions: wrap statements in a function; each call runs in BEGIN..COMMIT
+const addTodo = await conn.prepare("INSERT INTO todos (title) VALUES (?)");
+const addMany = conn.transaction((titles) => {
+  for (const title of titles) {
+    addTodo.run([title]);
+  }
+});
+await addMany(["Ship docs", "Review PR"]);
 ```
 
 ### Local-first with sync — `@tursodatabase/sync` (BETA)

--- a/integrations/agentic-stripe.mdx
+++ b/integrations/agentic-stripe.mdx
@@ -156,15 +156,18 @@ const conn = connect({
   authToken: process.env.MY_DB_AUTH_TOKEN,
 });
 
-// Execute a query
-const result = await conn.prepare("SELECT * FROM users WHERE active = ?").all([1]);
+// Execute a query — prepare() is async, await it before using the statement
+const stmt = await conn.prepare("SELECT * FROM users WHERE active = ?");
+const result = await stmt.all([1]);
 console.log(result);
 
 // Positional parameters
-await conn.prepare("SELECT * FROM users WHERE id = ?").get([1]);
+const byId = await conn.prepare("SELECT * FROM users WHERE id = ?");
+const row = await byId.get([1]);
 
 // Named parameters
-await conn.prepare("INSERT INTO users VALUES (:name)").run({ name: "Alice" });
+const insert = await conn.prepare("INSERT INTO users VALUES (:name)");
+await insert.run({ name: "Alice" });
 
 // Batch multiple statements in an implicit transaction
 await conn.batch([
@@ -173,10 +176,14 @@ await conn.batch([
   "INSERT INTO todos (title) VALUES ('Write code')",
 ]);
 
-// Interactive transaction
-const tx = await conn.transaction("write");
-await tx.prepare("UPDATE accounts SET balance = balance - ? WHERE id = ?").run([100, 1]);
-await tx.prepare("UPDATE accounts SET balance = balance + ? WHERE id = ?").run([100, 2]);
+// Transactions: wrap statements in a function; each call runs in BEGIN..COMMIT
+const addTodo = await conn.prepare("INSERT INTO todos (title) VALUES (?)");
+const addMany = conn.transaction((titles) => {
+  for (const title of titles) {
+    addTodo.run([title]);
+  }
+});
+await addMany(["Ship docs", "Review PR"]);
 await tx.commit();
 ```
 

--- a/integrations/agentic-vercel.mdx
+++ b/integrations/agentic-vercel.mdx
@@ -51,15 +51,18 @@ const conn = connect({
   authToken: process.env.TURSO_AUTH_TOKEN,
 });
 
-// Execute a query
-const result = await conn.prepare("SELECT * FROM users WHERE active = ?").all([1]);
+// Execute a query — prepare() is async, await it before using the statement
+const stmt = await conn.prepare("SELECT * FROM users WHERE active = ?");
+const result = await stmt.all([1]);
 console.log(result);
 
 // Positional parameters
-await conn.prepare("SELECT * FROM users WHERE id = ?").get([1]);
+const byId = await conn.prepare("SELECT * FROM users WHERE id = ?");
+const row = await byId.get([1]);
 
 // Named parameters
-await conn.prepare("INSERT INTO users VALUES (:name)").run({ name: "Alice" });
+const insert = await conn.prepare("INSERT INTO users VALUES (:name)");
+await insert.run({ name: "Alice" });
 
 // Batch multiple statements in an implicit transaction
 await conn.batch([
@@ -68,11 +71,14 @@ await conn.batch([
   "INSERT INTO todos (title) VALUES ('Write code')",
 ]);
 
-// Interactive transaction
-const tx = await conn.transaction("write");
-await tx.prepare("UPDATE accounts SET balance = balance - ? WHERE id = ?").run([100, 1]);
-await tx.prepare("UPDATE accounts SET balance = balance + ? WHERE id = ?").run([100, 2]);
-await tx.commit();
+// Transactions: wrap statements in a function; each call runs in BEGIN..COMMIT
+const addTodo = await conn.prepare("INSERT INTO todos (title) VALUES (?)");
+const addMany = conn.transaction((titles) => {
+  for (const title of titles) {
+    addTodo.run([title]);
+  }
+});
+await addMany(["Ship docs", "Review PR"]);
 ```
 
 ### In-Function SQLite — `@tursodatabase/vercel-experimental` (BETA)

--- a/integrations/vercel.mdx
+++ b/integrations/vercel.mdx
@@ -28,12 +28,12 @@ Connect to Turso databases from Vercel serverless and edge environments. Configu
 
 | | `@tursodatabase/serverless` | `@libsql/client` |
 | --- | --- | --- |
-| **Status** | Production-ready | Production-ready |
+| **Use with** | [Turso](/tursodb/quickstart) databases | [libSQL](/libsql) databases |
 | **Dependencies** | Uses only `fetch` — zero native dependencies | Requires Node.js or `/web` subpath |
-| **Concurrent writes** | Planned | Will not be supported |
+| **Concurrent writes** | Yes — built into the Turso engine | Not supported |
 | **ORM support** | Not yet supported | Drizzle, Prisma, and others |
 
-**`@tursodatabase/serverless`** is the lightest option with zero native dependencies — and will be the driver to later support concurrent writes. Use **`@libsql/client`** if you need a battle-tested driver today with ORM integration.
+Match the driver to your database engine: **`@tursodatabase/serverless`** for [Turso](/tursodb/quickstart) databases, **`@libsql/client`** for [libSQL](/libsql) databases and ORM integration (Drizzle, Prisma).
 
 ### Quickstart
 
@@ -54,7 +54,7 @@ Connect to Turso databases from Vercel serverless and edge environments. Configu
     authToken: process.env.TURSO_AUTH_TOKEN,
   });
 
-  const stmt = conn.prepare("SELECT * FROM users WHERE id = ?");
+  const stmt = await conn.prepare("SELECT * FROM users WHERE id = ?");
   const row = await stmt.get([123]);
   ```
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -29,7 +29,8 @@ Choose your path to get started with Turso:
     Filesystem and state SDK for AI agents with built-in auditability.
   </Card>
   <Card title="Turso Cloud" icon="cloud" href="/turso-cloud">
-    Fully managed database platform with branching, analytics, backups,and more.
+    Fully managed platform for Turso and libSQL databases, with branching,
+    analytics, backups, and more.
   </Card>
   <Card
     title="How Well You Know Turso?"

--- a/libsql.mdx
+++ b/libsql.mdx
@@ -34,11 +34,11 @@ libSQL is a fork of SQLite. It maintains the same file format, the same API, and
 | | libSQL | Turso Database |
 |---|---|---|
 | Approach | Fork of SQLite | Full rewrite of SQLite |
-| Maturity | Production-ready | Evolving (beta) |
+| Maturity | Production-ready | Production-ready |
 | SQLite compatibility | Full (same file format and API) | Backwards compatible |
 | Best for | Mission-critical workloads today | New projects, agents, smart devices, high-density use cases |
 
-Both are open-contribution and maintained by Turso. [Turso Cloud](/turso-cloud) currently runs on libSQL and will integrate the Turso Database engine in the future.
+Both are open-contribution and maintained by Turso, and both can be deployed on [Turso Cloud](/turso-cloud): libSQL has powered it for years, and Turso databases are now available on the platform as well.
 
 ## Extensions
 

--- a/local-development.mdx
+++ b/local-development.mdx
@@ -1,13 +1,12 @@
 ---
 title: Local Development
-description: Build locally using SQLite, libSQL Server or Turso.
+description: Build locally with a local Turso database, or a local libSQL server.
 ---
 
 Developers can build locally with Turso using either of the following methods:
 
-- [SQLite](#sqlite) &mdash; local SQLite database file
+- [Local Turso database](#local-turso-database) &mdash; local database file, no server needed (recommended)
 - [Turso CLI](#turso-cli) &mdash; managed libSQL server
-- [Turso Database](#turso-database) &mdash; remote Turso database
 
 ## Using a dump locally
 
@@ -30,39 +29,30 @@ cat dump.sql | sqlite3 local.db
 
   </Step>
 
-  <Step title="Connect to SQLite file">
+  <Step title="Connect to the file">
 
-    You can use any of the methods below with the `local.db` file, or you can use a new file name if you prefer to create a database from scratch.
+    You can use either of the methods below with the `local.db` file, or you can use a new file name if you prefer to create a database from scratch.
 
   </Step>
 </Steps>
 
-## SQLite
+## Local Turso database
 
-There are a few things to keep in mind when using SQLite for local development:
-
-- Doesn't have all the features of libSQL
-- Works with non-serverless based Turso SDKs
-
-When working with an [SDK](/sdk), you can pass it a `file:` URL to connect to a SQLite database file instead of a remote Turso database:
+Whenever your application runs against a local database, we recommend the [Turso packages](/sdk). They are fully SQLite-compatible — they open existing SQLite files — and run entirely in your process, no server needed:
 
 <CodeGroup>
 
 ```ts JavaScript
-import { createClient } from "@libsql/client";
+import { connect } from "@tursodatabase/database";
 
-const client = createClient({
-  url: "file:local.db",
-});
+const db = await connect("local.db");
 ```
 
 ```rust Rust
-let client = libsql_client::Client::from_config(libsql_client::Config {
-    url: url::Url::parse("file:local.db").unwrap(),
-    auth_token: None,
-})
-.await
-.unwrap();
+use turso::Builder;
+
+let db = Builder::new_local("local.db").build().await?;
+let conn = db.connect()?;
 ```
 
 ```go Go
@@ -70,30 +60,20 @@ package main
 
 import (
   "database/sql"
-  "fmt"
-  "os"
 
-  _ "github.com/tursodatabase/go-libsql"
+  _ "turso.tech/database/tursogo"
 )
 
 func main() {
-  dbName := "file:./local.db"
-
-  db, err := sql.Open("libsql", dbName)
-  if err != nil {
-    fmt.Fprintf(os.Stderr, "failed to open db %s", err)
-    os.Exit(1)
-  }
+  db, _ := sql.Open("turso", "local.db")
   defer db.Close()
 }
 ```
 
 ```python Python
-import libsql_client
+import turso
 
-client = libsql_client.create_client_sync(
-    url="file:local.db"
-)
+db = turso.connect("local.db")
 ```
 
 </CodeGroup>
@@ -114,15 +94,13 @@ It's recommended to use environment variables for both `url` and `authToken` for
 
 ## Turso CLI
 
-If you're using [libSQL](/libsql) specific features like [extensions](/libsql#extensions), you should use the Turso CLI:
+If you're developing against a [libSQL](/libsql) database and use libSQL-specific features like [extensions](/libsql#extensions), you should use the Turso CLI:
 
 ```bash
 turso dev
 ```
 
-This will start a local libSQL server and create a database for you. You can then connect to it using the `url` option in your SDK:
-
-<CodeGroup>
+This will start a local libSQL server and create a database for you. You can then connect to it with your libSQL client using the `url` option:
 
 ```ts JavaScript
 import { createClient } from "@libsql/client";
@@ -132,24 +110,7 @@ const client = createClient({
 });
 ```
 
-```rust Rust
-let client = libsql_client::Client::from_config(libsql_client::Config {
-    url: url::Url::parse("http://127.0.0.1:8080").unwrap(),
-    auth_token: None,
-})
-.await
-.unwrap();
-```
-
-```python Python
-import libsql_client
-
-client = libsql_client.create_client_sync(
-    url="http://127.0.0.1:8080"
-)
-```
-
-</CodeGroup>
+The same URL works with the libSQL clients for [other languages](/sdk).
 
 <br />
 
@@ -165,13 +126,13 @@ If you want to persist changes, or use a production dump, you can pass the `--db
 turso dev --db-file local.db
 ```
 
-## Turso Database
+## Turso Cloud database
 
-If you already have a database created with Turso, you can use that same one in development by passing the `url` option to your SDK.
+If you already have a database created on Turso Cloud, you can use that same one in development by passing the `url` option to your SDK.
 
 <Warning>
 
-Keep in mind that using the Turso hosted database will incur platform costs and count towards your quota. Consider using [SQLite](#sqlite) or [Turso CLI](#turso-cli) for local development to avoid platform costs.
+Keep in mind that using the Turso Cloud hosted database will incur platform costs and count towards your quota. Consider one of the local methods above to avoid platform costs.
 
 </Warning>
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -54,7 +54,13 @@ turso auth login
 
 <Step title="Create a Database">
 
-Now create your first database with the name `my-db`:
+Turso Cloud hosts two SQLite-compatible engines: [Turso](/tursodb/quickstart), with concurrent writes and multi-user access built in, and [libSQL](/libsql). Create your first Turso database with the name `my-db`:
+
+```bash
+turso db create my-db --tursodb
+```
+
+To create a libSQL database instead, omit the `--tursodb` flag:
 
 ```bash
 turso db create my-db

--- a/scripts/sync-sql-reference.py
+++ b/scripts/sync-sql-reference.py
@@ -188,7 +188,7 @@ CLI_ORDER = [
 
 CLI_REFERENCE_GROUP_NAME = "CLI Reference"
 SQL_REFERENCE_GROUP_NAME = "SQL Reference"
-TURSO_DB_TAB_NAME = "Turso Database (beta)"
+TURSO_DB_TAB_NAME = "Turso Database"
 
 
 def copy_and_rewrite(src_dir: str, dest_dir: str) -> list[str]:

--- a/sdk/authentication.mdx
+++ b/sdk/authentication.mdx
@@ -2,13 +2,17 @@
 title: Authentication
 ---
 
-SDKs connect to Turso using the `libsql://` protocol, unless using the [HTTP API](/sdk/http).
+SDKs connect using the `turso://` protocol for [Turso](/tursodb/quickstart) databases and the `libsql://` protocol for [libSQL](/libsql) databases, unless using the [HTTP API](/sdk/http).
 
 ## Database URL
 
 You can find your database URL using the [Turso CLI](/cli/db/show) or [Platform API](/api-reference/databases/retrieve), it looks something like this:
 
 <CodeGroup>
+
+```bash Turso
+turso://[DB-NAME]-[ORG-NAME].turso.io
+```
 
 ```bash libSQL
 libsql://[DB-NAME]-[ORG-NAME].turso.io
@@ -19,6 +23,12 @@ https://[DB-NAME]-[ORG-NAME].turso.io
 ```
 
 </CodeGroup>
+
+<Info>
+
+Turso databases accept both the `turso://` and `libsql://` schemes. Use `turso://` to make it clear the database runs on the Turso engine.
+
+</Info>
 
 <br />
 

--- a/sdk/authentication.mdx
+++ b/sdk/authentication.mdx
@@ -24,12 +24,6 @@ https://[DB-NAME]-[ORG-NAME].turso.io
 
 </CodeGroup>
 
-<Info>
-
-Turso databases accept both the `turso://` and `libsql://` schemes. Use `turso://` to make it clear the database runs on the Turso engine.
-
-</Info>
-
 <br />
 
 <Info>

--- a/sdk/authorization.mdx
+++ b/sdk/authorization.mdx
@@ -45,9 +45,9 @@ Both approaches support [fine-grained permissions](/sdk/authorization/fine-grain
 All tokens are passed as the `authToken` when creating a database client:
 
 ```javascript
-import { createClient } from "@tursodatabase/serverless";
+import { connect } from "@tursodatabase/serverless";
 
-const db = createClient({
+const db = connect({
   url: "<your-database-url>",
   authToken: "<your-token>",
 });

--- a/sdk/authorization/jwks.mdx
+++ b/sdk/authorization/jwks.mdx
@@ -55,11 +55,11 @@ You can also add JWKS endpoints in the [Turso Dashboard](https://turso.tech/app)
 Get the JWT from your auth provider and pass it as the `authToken`:
 
 ```javascript
-import { createClient } from "@tursodatabase/serverless";
+import { connect } from "@tursodatabase/serverless";
 
 const authToken = await getAuthToken(); // e.g., from Clerk, Auth0
 
-const db = createClient({
+const db = connect({
   url: "<your-database-url>",
   authToken,
 });

--- a/sdk/go/quickstart.mdx
+++ b/sdk/go/quickstart.mdx
@@ -113,7 +113,7 @@ Then set `RemoteUrl` to `http://127.0.0.1:8080` (no `AuthToken` needed). See [Tu
 
 ## Remote Access (Over-the-Wire)
 
-If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), use the `libsql-client-go` package. It connects to your database via the libSQL wire protocol — no local file needed, pure Go.
+If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), use the driver that matches your database engine: `tursogo-serverless` for [Turso databases](/tursodb/quickstart), or `libsql-client-go` for [libSQL](/libsql) databases.
 
 <Info>
 
@@ -121,10 +121,69 @@ For most applications, we recommend running a local database with sync (`NewTurs
 
 </Info>
 
+### Remote Turso database: tursogo-serverless
+
+`tursogo-serverless` connects to a remote Turso database over HTTP — pure Go, no CGO, no native libraries. It implements the standard `database/sql` interface, compatible with the embedded `tursogo` driver.
+
 <Steps>
   <Step title="Retrieve database credentials">
 
-You will need an existing database to continue. If you don't have one, [create one](/quickstart).
+You will need an existing Turso database to continue. If you don't have one, create one with `turso db create --tursodb` (see the [quickstart](/quickstart)).
+
+<Snippet file="retrieve-database-credentials-tursodb.mdx" />
+
+<Info>You will want to store these as environment variables.</Info>
+
+  </Step>
+  <Step title="Install">
+
+```bash
+go get turso.tech/database/tursogo-serverless
+```
+
+  </Step>
+  <Step title="Connect and query">
+
+```go
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	turso "turso.tech/database/tursogo-serverless"
+)
+
+func main() {
+	db := sql.OpenDB(turso.NewConnector(
+		os.Getenv("TURSO_DATABASE_URL"),
+		os.Getenv("TURSO_AUTH_TOKEN"),
+	))
+	defer db.Close()
+
+	rows, _ := db.Query("SELECT * FROM users")
+	defer rows.Close()
+	for rows.Next() {
+		var id int
+		var name string
+		rows.Scan(&id, &name)
+		fmt.Printf("User: %d %s\n", id, name)
+	}
+}
+```
+
+  </Step>
+</Steps>
+
+### Remote libSQL database: libsql-client-go
+
+`libsql-client-go` connects to a remote libSQL database via the libSQL wire protocol — no local file needed, pure Go.
+
+<Steps>
+  <Step title="Retrieve database credentials">
+
+You will need an existing libSQL database to continue. If you don't have one, [create one](/quickstart).
 
 <Snippet file="retrieve-database-credentials.mdx" />
 

--- a/sdk/go/reference.mdx
+++ b/sdk/go/reference.mdx
@@ -3,18 +3,18 @@ title: Reference
 description: Go Reference for Turso
 ---
 
-Turso offers two Go packages:
+Turso offers four Go packages:
 
-| | `tursogo` | `libsql-client-go` | `go-libsql` |
-| --- | --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Remote access (over-the-wire) | Existing libSQL codebases |
-| **Engine** | Turso Database (rewrite) | libSQL wire protocol | libSQL (SQLite fork) |
-| **Concurrent writes** | Yes (MVCC) | N/A (remote) | Not supported |
-| **Sync** | push/pull (local-first) | — | Embedded Replicas (writes go to cloud primary) |
-| **CGO** | Not required | Not required | Required |
-| **API** | `database/sql` | `database/sql` | `database/sql` |
+| | `tursogo` | `tursogo-serverless` | `libsql-client-go` | `go-libsql` |
+| --- | --- | --- | --- | --- |
+| **Use case** | Local / embedded database, sync | Remote Turso database (over-the-wire) | Remote libSQL database (over-the-wire) | Existing libSQL codebases |
+| **Engine** | Turso (rewrite) | Turso (rewrite) | libSQL wire protocol | libSQL (SQLite fork) |
+| **Concurrent writes** | Yes (MVCC) | Yes (MVCC) | N/A (remote) | Not supported |
+| **Sync** | push/pull (local-first) | — | — | Embedded Replicas (writes go to cloud primary) |
+| **CGO** | Not required | Not required | Not required | Required |
+| **API** | `database/sql` | `database/sql` | `database/sql` | `database/sql` |
 
-**Starting a new project?** Use `tursogo` for local/embedded use or sync. Use `libsql-client-go` for remote access. Neither requires CGO.
+**Starting a new project?** Use `tursogo` for local/embedded use or sync. For remote access, match the driver to the database engine: [`tursogo-serverless`](/sdk/go/quickstart) for Turso databases, `libsql-client-go` for libSQL databases. None of these require CGO.
 
 ## tursogo
 

--- a/sdk/http/quickstart.mdx
+++ b/sdk/http/quickstart.mdx
@@ -11,11 +11,11 @@ In this quickstart we will learn how to:
 
 | | `@tursodatabase/serverless` | `@libsql/client` | Raw HTTP |
 | --- | --- | --- | --- |
-| **Status** | Production-ready | Production-ready | Always available |
+| **Use with** | [Turso](/tursodb/quickstart) databases | [libSQL](/libsql) databases | Any database |
 | **Dependencies** | Uses only `fetch` — zero native dependencies | Requires Node.js or `/web` subpath | None (any HTTP client) |
 | **ORM support** | Not yet supported | Drizzle, Prisma, and others | N/A |
 
-**`@tursodatabase/serverless`** is the lightest option with zero native dependencies. Use **`@libsql/client`** if you need a battle-tested driver today with ORM integration.
+Match the driver to your database engine: **`@tursodatabase/serverless`** for [Turso](/tursodb/quickstart) databases, **`@libsql/client`** for [libSQL](/libsql) databases.
 
 <Tabs>
   <Tab title="@tursodatabase/serverless">
@@ -36,12 +36,12 @@ In this quickstart we will learn how to:
   ```typescript
   import { connect } from "@tursodatabase/serverless";
 
-  const conn = await connect({
+  const conn = connect({
     url: process.env.TURSO_DATABASE_URL,
     authToken: process.env.TURSO_AUTH_TOKEN,
   });
 
-  const stmt = conn.prepare("SELECT * FROM users WHERE id = ?");
+  const stmt = await conn.prepare("SELECT * FROM users WHERE id = ?");
   const row = await stmt.get([123]);
   ```
 

--- a/sdk/http/reference.mdx
+++ b/sdk/http/reference.mdx
@@ -14,7 +14,7 @@ It's recommended you use a [native SDK](/sdk).
 
 ## Base URL
 
-Simply replace your database URL protocol `libsql://` with `https://`:
+Simply replace your database URL protocol (`turso://` for Turso databases, `libsql://` for libSQL databases) with `https://`:
 
 ```bash
 https://[databaseName]-[organizationSlug].turso.io

--- a/sdk/introduction.mdx
+++ b/sdk/introduction.mdx
@@ -5,14 +5,19 @@ title: Turso SDKs
 
 ## Which package should I use?
 
+Two rules cover almost every case:
+
+1. **If a local database is involved, use the Turso packages.** That means fully local databases (embedded, on-device, offline) and local databases that sync with the cloud — even when the database on the other side is libSQL.
+2. **If your application only talks to a cloud database over the network, match the driver to the database engine.** [Turso databases](/tursodb/quickstart) use the serverless drivers; [libSQL](/libsql) databases use the libSQL clients.
+
 | Use case | TypeScript | Python | Go | Rust |
 | --- | --- | --- | --- | --- |
 | **Local database** (embedded, on-device, offline) | `@tursodatabase/database` | `pyturso` | `tursogo` | `turso` |
 | **Local database + cloud sync** (push/pull) | `@tursodatabase/sync` | `pyturso` (with sync) | `tursogo` (with sync) | `turso` (with `sync` feature) |
-| **Remote access** (servers, Docker, serverless, edge — any over-the-wire) | `@tursodatabase/serverless` | `libsql` | `libsql-client-go` | `libsql` (with `remote` feature) |
-| **libSQL** — ORM support (Drizzle, Prisma), production-ready, battle-tested | `@libsql/client` | `libsql` | `go-libsql` | `libsql` |
+| **Remote Turso database** (over-the-wire) | `@tursodatabase/serverless` | `turso_serverless` | `tursogo-serverless` | `turso_serverless` |
+| **Remote libSQL database** (over-the-wire) | `@libsql/client` | `libsql` | `libsql-client-go` | `libsql` (with `remote` feature) |
 
-**Starting a new project?** Use `@tursodatabase/database` (TypeScript), `pyturso` (Python), `tursogo` (Go), or `turso` (Rust). These are built on the Turso Database engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and local-first sync.
+**Starting a new project?** Use `@tursodatabase/database` (TypeScript), `pyturso` (Python), `tursogo` (Go), or `turso` (Rust). These are built on the Turso engine — the ground-up rewrite of SQLite with concurrent writes, async I/O, and local-first sync.
 
 **Need sync?** Use [Turso Sync](/sync/usage) for local reads and writes with explicit `push()` / `pull()` to Turso Cloud.
 
@@ -22,13 +27,13 @@ title: Turso SDKs
 - **Rust** — [Toasty](/sdk/rust/orm/toasty), the async ORM from the Tokio project, has a native Turso driver built on the `turso` crate.
 - **Python** — see the [SQLAlchemy guide](/sdk/python/orm/sqlalchemy).
 
-**Migrating from SQLite?** Turso Database is a drop-in replacement. Your existing SQL, schema, and queries work unchanged.
+**Migrating from SQLite?** Turso is a drop-in replacement. Your existing SQL, schema, and queries work unchanged.
 
-**Already using `@libsql/client`, `libsql`, or `go-libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. They are production-ready and battle-tested. If your workload needs concurrent writes, push/pull sync, or local-first writes (offline / multi-writer / bidirectional), the Turso Database packages are also a good choice — pick the one that fits your workload.
+**Already using `@libsql/client`, `libsql`, or `go-libsql`?** These packages are built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that has powered Turso Cloud for years. They are production-ready and battle-tested, and remain the recommended way to access libSQL databases remotely. If your workload needs concurrent writes, push/pull sync, or local-first writes (offline / multi-writer / bidirectional), consider a Turso database and its packages instead.
 
-### Why multiple packages in TypeScript?
+### The serverless drivers
 
-Keeping `@tursodatabase/database` and `@tursodatabase/serverless` separate means minimal bundle size. `@tursodatabase/serverless` uses only `fetch` — zero native dependencies, so it works in Node.js, Docker containers, serverless functions, edge runtimes, and browsers.
+The serverless drivers speak SQL over HTTP — no persistent connections, no native libraries. They work anywhere your language runs: servers, Docker containers, serverless functions, and edge runtimes. Each mirrors the API of its embedded counterpart, so code moves between local and remote with minimal changes.
 
 <Info>
   **Need sync?** For new projects, use [Turso Sync](/sync/usage) — it gives you local reads and writes with explicit `push()` / `pull()` to the cloud. The libSQL-based SDKs below also support Embedded Replicas, where reads are local and writes are sent to the cloud primary.

--- a/sdk/python/quickstart.mdx
+++ b/sdk/python/quickstart.mdx
@@ -87,7 +87,7 @@ All reads and writes happen against the local database file — fast, offline-ca
 
 ## Remote Access (Over-the-Wire)
 
-If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), you can use the `libsql` package. It connects to your database via HTTP — no local file needed.
+If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), use the driver that matches your database engine: `turso_serverless` for [Turso databases](/tursodb/quickstart), or `libsql` for [libSQL](/libsql) databases.
 
 <Info>
 
@@ -95,10 +95,65 @@ For most applications, we recommend running a local database with [Turso Sync](/
 
 </Info>
 
+### Remote Turso database: turso_serverless
+
+`turso_serverless` connects to a remote Turso database over HTTP — no persistent connections, no native extensions, just the standard library. Like `pyturso`, it implements the standard DB-API interface.
+
 <Steps>
   <Step title="Retrieve database credentials">
 
-You will need an existing database to continue. If you don't have one, [create one](/quickstart).
+You will need an existing Turso database to continue. If you don't have one, create one with `turso db create --tursodb` (see the [quickstart](/quickstart)).
+
+<Snippet file="retrieve-database-credentials-tursodb.mdx" />
+
+<Info>You will want to store these as environment variables.</Info>
+
+  </Step>
+  <Step title="Install">
+
+```bash
+uv add turso_serverless
+```
+
+Or with pip:
+
+```bash
+pip install turso_serverless
+```
+
+  </Step>
+  <Step title="Connect and query">
+
+```py
+import os
+import turso_serverless
+
+conn = turso_serverless.connect(
+    os.environ["TURSO_DATABASE_URL"],
+    auth_token=os.environ["TURSO_AUTH_TOKEN"],
+)
+
+conn.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+conn.execute("INSERT INTO users (name) VALUES (?)", ("Alice",))
+conn.commit()
+
+for row in conn.execute("SELECT * FROM users"):
+    print(row)
+
+conn.close()
+```
+
+  </Step>
+</Steps>
+
+### Remote libSQL database: libsql
+
+`libsql` connects to a remote libSQL database via HTTP — no local file needed.
+
+<Steps>
+  <Step title="Retrieve database credentials">
+
+You will need an existing libSQL database to continue. If you don't have one, [create one](/quickstart).
 
 <Snippet file="retrieve-database-credentials.mdx" />
 

--- a/sdk/python/reference.mdx
+++ b/sdk/python/reference.mdx
@@ -3,17 +3,17 @@ title: Reference
 description: Python Reference for Turso
 ---
 
-Turso offers two Python packages:
+Turso offers three Python packages:
 
-| | `pyturso` | `libsql` |
-| --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Existing libSQL codebases |
-| **Engine** | Turso Database (rewrite) | libSQL (SQLite fork) |
-| **Concurrent writes** | Yes (MVCC) | Not supported |
-| **Sync** | push/pull (local-first) | Embedded Replicas (writes go to cloud primary) |
-| **API** | Python `sqlite3`-compatible | Python `sqlite3`-compatible |
+| | `pyturso` | `turso_serverless` | `libsql` |
+| --- | --- | --- | --- |
+| **Use case** | Local / embedded database, sync | Remote Turso database (over-the-wire) | Remote libSQL database, existing libSQL codebases |
+| **Engine** | Turso (rewrite) | Turso (rewrite) | libSQL (SQLite fork) |
+| **Concurrent writes** | Yes (MVCC) | Yes (MVCC) | Not supported |
+| **Sync** | push/pull (local-first) | — | Embedded Replicas (writes go to cloud primary) |
+| **API** | Python `sqlite3`-compatible | Python `sqlite3`-compatible | Python `sqlite3`-compatible |
 
-**Starting a new project?** Use `pyturso` — it is built on the Turso Database engine with concurrent writes and local-first sync.
+**Starting a new project?** Use `pyturso` — it is built on the Turso engine with concurrent writes and local-first sync. For remote access over the network, match the driver to the database engine: [`turso_serverless`](/sdk/python/quickstart) for Turso databases, `libsql` for libSQL databases.
 
 ## pyturso
 

--- a/sdk/rust/quickstart.mdx
+++ b/sdk/rust/quickstart.mdx
@@ -107,7 +107,7 @@ Then use `http://127.0.0.1:8080` as the remote URL (no auth token needed). See [
 
 ## Remote Access (Over-the-Wire)
 
-If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), use the `libsql` crate with the `remote` feature. It connects over HTTP — no local file needed, no C compiler required.
+If your application needs to query a Turso Cloud database directly over the network (e.g., from a web server or serverless function), use the crate that matches your database engine: `turso_serverless` for [Turso databases](/tursodb/quickstart), or `libsql` (with the `remote` feature) for [libSQL](/libsql) databases.
 
 <Info>
 
@@ -115,10 +115,62 @@ For most applications, we recommend running a local database with sync (`turso::
 
 </Info>
 
+### Remote Turso database: turso_serverless
+
+`turso_serverless` connects to a remote Turso database over HTTP — no persistent connections, no C compiler required. Its API mirrors the embedded `turso` crate, so code moves between local and remote with minimal changes.
+
 <Steps>
   <Step title="Retrieve database credentials">
 
-You will need an existing database to continue. If you don't have one, [create one](/quickstart).
+You will need an existing Turso database to continue. If you don't have one, create one with `turso db create --tursodb` (see the [quickstart](/quickstart)).
+
+<Snippet file="retrieve-database-credentials-tursodb.mdx" />
+
+<Info>You will want to store these as environment variables.</Info>
+
+  </Step>
+  <Step title="Install">
+
+```bash
+cargo add turso_serverless tokio --features tokio/full
+```
+
+  </Step>
+  <Step title="Connect and query">
+
+```rust
+use turso_serverless::Builder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = Builder::new_remote(std::env::var("TURSO_DATABASE_URL")?)
+        .with_auth_token(std::env::var("TURSO_AUTH_TOKEN")?)
+        .build()
+        .await?;
+    let conn = db.connect()?;
+
+    let mut rows = conn.query("SELECT * FROM users", ()).await?;
+    while let Some(row) = rows.next().await? {
+        let id: i64 = row.get(0)?;
+        let name: String = row.get(1)?;
+        println!("User: {} {}", id, name);
+    }
+
+    Ok(())
+}
+```
+
+  </Step>
+</Steps>
+
+### Remote libSQL database: libsql
+
+The `libsql` crate with the `remote` feature connects to a remote libSQL database over HTTP — no local file needed, no C compiler required.
+
+<Steps>
+  <Step title="Retrieve database credentials">
+
+You will need an existing libSQL database to continue. If you don't have one, [create one](/quickstart).
 
 <Snippet file="retrieve-database-credentials.mdx" />
 

--- a/sdk/rust/reference.mdx
+++ b/sdk/rust/reference.mdx
@@ -3,17 +3,17 @@ title: Reference
 description: Rust Reference for Turso
 ---
 
-Turso offers two Rust crates:
+Turso offers three Rust crates:
 
-| | `turso` | `libsql` |
-| --- | --- | --- |
-| **Use case** | Local / embedded database, sync | Remote access, existing libSQL codebases |
-| **Engine** | Turso Database (rewrite) | libSQL (SQLite fork) |
-| **Concurrent writes** | Yes (MVCC) | Not supported |
-| **Sync** | push/pull (local-first) | Embedded Replicas (writes go to cloud primary) |
-| **C compiler** | Not required | Required for `core`, `replication`, `encryption` features |
+| | `turso` | `turso_serverless` | `libsql` |
+| --- | --- | --- | --- |
+| **Use case** | Local / embedded database, sync | Remote Turso database (over-the-wire) | Remote libSQL database, existing libSQL codebases |
+| **Engine** | Turso (rewrite) | Turso (rewrite) | libSQL (SQLite fork) |
+| **Concurrent writes** | Yes (MVCC) | Yes (MVCC) | Not supported |
+| **Sync** | push/pull (local-first) | — | Embedded Replicas (writes go to cloud primary) |
+| **C compiler** | Not required | Not required | Required for `core`, `replication`, `encryption` features |
 
-**Starting a new project?** Use `turso` for local/embedded use or sync. Use `libsql` with the `remote` feature for over-the-wire access (no C compiler needed).
+**Starting a new project?** Use `turso` for local/embedded use or sync. For remote access, match the crate to the database engine: [`turso_serverless`](/sdk/rust/quickstart) for Turso databases, `libsql` with the `remote` feature for libSQL databases (no C compiler needed).
 
 ## turso
 

--- a/sdk/ts/quickstart.mdx
+++ b/sdk/ts/quickstart.mdx
@@ -83,16 +83,16 @@ All reads and writes happen against the local database file — fast, offline-ca
   </Step>
 </Steps>
 
-## Recommended: @tursodatabase/serverless (Remote / Over-the-Wire)
+## Remote Turso database: @tursodatabase/serverless
 
-`@tursodatabase/serverless` is the recommended package for **any application that connects to a remote Turso Cloud database over the network** — including Node.js servers, Docker containers, serverless functions, and edge runtimes (Cloudflare Workers, Vercel Edge, Deno Deploy). It uses only `fetch` — zero native dependencies, works everywhere.
+`@tursodatabase/serverless` is the package for applications that connect to a remote [Turso database](/tursodb/quickstart) on Turso Cloud over the network — including Node.js servers, Docker containers, serverless functions, and edge runtimes (Cloudflare Workers, Vercel Edge, Deno Deploy). It uses only `fetch` — zero native dependencies, works everywhere.
 
 <Steps>
   <Step title="Retrieve database credentials">
 
-You will need an existing database to continue. If you don't have one, [create one](/quickstart).
+You will need an existing Turso database to continue. If you don't have one, create one with `turso db create --tursodb` (see the [quickstart](/quickstart)).
 
-<Snippet file="retrieve-database-credentials.mdx" />
+<Snippet file="retrieve-database-credentials-tursodb.mdx" />
 
 <Info>You will want to store these as environment variables.</Info>
 
@@ -144,9 +144,9 @@ const row = await stmt.get([1]);
   </Step>
 </Steps>
 
-## @libsql/client
+## Remote libSQL database: @libsql/client
 
-Use `@libsql/client` for ORM integration (Drizzle, Prisma) or if you have an existing codebase built on it. See the [reference](/sdk/ts/reference#libsqlclient) for full documentation.
+`@libsql/client` is the package for applications that connect to a remote [libSQL](/libsql) database on Turso Cloud. It is also the package to use for ORM integration (Drizzle, Prisma). See the [reference](/sdk/ts/reference#libsqlclient) for full documentation.
 
 <Steps>
   <Step title="Install">

--- a/sdk/ts/reference.mdx
+++ b/sdk/ts/reference.mdx
@@ -3,18 +3,18 @@ title: Reference
 description: TypeScript Reference for Turso
 ---
 
-Turso offers three TypeScript packages:
+Turso offers four TypeScript packages:
 
 | | `@tursodatabase/database` | `@tursodatabase/sync` | `@tursodatabase/serverless` | `@libsql/client` |
 | --- | --- | --- | --- | --- |
-| **Use case** | Local / embedded database | Local database + cloud sync | Remote access (servers, containers, serverless, edge) | ORM support (Drizzle, Prisma) |
-| **Engine** | Turso Database (rewrite) | Turso Database (rewrite) | Turso Database | libSQL (SQLite fork) |
+| **Use case** | Local / embedded database | Local database + cloud sync | Remote Turso database (servers, containers, serverless, edge) | Remote libSQL database, ORM support (Drizzle, Prisma) |
+| **Engine** | Turso (rewrite) | Turso (rewrite) | Turso | libSQL (SQLite fork) |
 | **Dependencies** | Native (Node.js, WASM) | Native (Node.js) | `fetch` only — zero native deps | Requires Node.js or `/web` subpath |
-| **Concurrent writes** | Yes (MVCC) | Yes (MVCC) | Planned | Not supported |
+| **Concurrent writes** | Yes (MVCC) | Yes (MVCC) | Yes (MVCC) | Not supported |
 | **Sync** | — | push/pull (local-first) | — | Embedded Replicas (writes go to cloud primary) |
 | **ORM support** | Drizzle (beta) | — | — | Drizzle, Prisma, and others |
 
-**Starting a new project?** Use `@tursodatabase/database` for local/embedded use, `@tursodatabase/sync` for local + cloud sync, or `@tursodatabase/serverless` for any application that connects to a remote Turso Cloud database (Node.js servers, Docker containers, serverless functions, edge runtimes). **Using an ORM?** Use `@libsql/client` — it's production-ready and supported by Drizzle, Prisma, and others. Drizzle has [beta support](https://orm.drizzle.team/docs/connect-turso-database) for `@tursodatabase/database` for local/embedded use.
+**Starting a new project?** Use `@tursodatabase/database` for local/embedded use, `@tursodatabase/sync` for local + cloud sync, and `@tursodatabase/serverless` to reach a remote [Turso database](/tursodb/quickstart) over the network (Node.js servers, Docker containers, serverless functions, edge runtimes). **Connecting to a remote [libSQL](/libsql) database, or using an ORM?** Use `@libsql/client` — it's production-ready and supported by Drizzle, Prisma, and others. Drizzle has [beta support](https://orm.drizzle.team/docs/connect-turso-database) for `@tursodatabase/database` for local/embedded use.
 
 The following runtime environments are known to be compatible:
 
@@ -183,7 +183,7 @@ const row = await stmt2.get([1]);
 
 ## @libsql/client
 
-The `@libsql/client` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that powers Turso Cloud today. It is production-ready, battle-tested, and the right choice when you need ORM integration beyond Drizzle (e.g., Prisma) or are working with an existing `@libsql/client`-based codebase.
+The `@libsql/client` package is built on [libSQL](https://github.com/tursodatabase/libsql), the open-source fork of SQLite that has powered Turso Cloud for years. It is production-ready, battle-tested, and the right choice for remote access to libSQL databases, when you need ORM integration beyond Drizzle (e.g., Prisma), or when working with an existing `@libsql/client`-based codebase.
 
 <Info>
 

--- a/sync/local-sync-server.mdx
+++ b/sync/local-sync-server.mdx
@@ -47,7 +47,7 @@ conn = turso.sync.connect(
 package main
 
 import (
-	"turso"
+	turso "turso.tech/database/tursogo"
 )
 
 db, err := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{

--- a/sync/partial.mdx
+++ b/sync/partial.mdx
@@ -67,15 +67,15 @@ conn = turso.sync.connect(
 
 ```go Go
 import (
-	"turso"
+	turso "turso.tech/database/tursogo"
 )
 
 db, err := turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
-  Path:            "./app.db",
-  RemoteUrl:       "turso://...",
-  RemoteAuthToken: os.Getenv("TURSO_AUTH_TOKEN"),
-  PartialSyncConfig: turso.TursoPartialSyncConfig{
-    BoostrapStrategyPrefix: 128 * 1024, // 128 KiB
+  Path:      "./app.db",
+  RemoteUrl: "turso://...",
+  AuthToken: os.Getenv("TURSO_AUTH_TOKEN"),
+  PartialSyncExperimental: turso.TursoPartialSyncConfig{
+    BootstrapStrategyPrefix: 128 * 1024, // 128 KiB
   },
 })
 ```
@@ -118,15 +118,15 @@ conn = turso.sync.connect(
 
 ```go Go
 import (
-	"turso"
+	turso "turso.tech/database/tursogo"
 )
 
 db, err := turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
-  Path:            "./app.db",
-  RemoteUrl:       "turso://...",
-  RemoteAuthToken: os.Getenv("TURSO_AUTH_TOKEN"),
-  PartialSyncConfig: turso.TursoPartialSyncConfig{
-    BoostrapStrategyQuery: "SELECT * FROM messages WHERE user_id = 'u_123' LIMIT 100",
+  Path:      "./app.db",
+  RemoteUrl: "turso://...",
+  AuthToken: os.Getenv("TURSO_AUTH_TOKEN"),
+  PartialSyncExperimental: turso.TursoPartialSyncConfig{
+    BootstrapStrategyQuery: "SELECT * FROM messages WHERE user_id = 'u_123' LIMIT 100",
   },
 })
 ```

--- a/sync/partial.mdx
+++ b/sync/partial.mdx
@@ -43,7 +43,7 @@ import { connect } from '@tursodatabase/sync';
 
 const db = await connect({
   path: './app.db',
-  url: 'libsql://...',
+  url: 'turso://...',
   authToken: process.env.TURSO_AUTH_TOKEN,
   partialSyncExperimental: {
     bootstrapStrategy: { kind: 'prefix', length: 128 * 1024 }, // 128 KiB
@@ -57,7 +57,7 @@ import turso.sync
 
 conn = turso.sync.connect(
     path="./app.db",
-    remote_url="libsql://...",
+    remote_url="turso://...",
     remote_auth_token=os.environ["TURSO_AUTH_TOKEN"],
     partial_sync_opts=turso.sync.PartialSyncOpts(
         bootstrap_strategy=turso.sync.PartialSyncPrefixBootstrap(length=128 * 1024),
@@ -72,7 +72,7 @@ import (
 
 db, err := turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
   Path:            "./app.db",
-  RemoteUrl:       "libsql://...",
+  RemoteUrl:       "turso://...",
   RemoteAuthToken: os.Getenv("TURSO_AUTH_TOKEN"),
   PartialSyncConfig: turso.TursoPartialSyncConfig{
     BoostrapStrategyPrefix: 128 * 1024, // 128 KiB
@@ -91,7 +91,7 @@ import { connect } from '@tursodatabase/sync';
 
 const db = await connect({
   path: './app.db',
-  url: 'libsql://...',
+  url: 'turso://...',
   authToken: process.env.TURSO_AUTH_TOKEN,
   partialSyncExperimental: {
     bootstrapStrategy: {
@@ -107,7 +107,7 @@ import turso.sync
 
 conn = turso.sync.connect(
     path=":memory:",
-    remote_url="libsql://...",
+    remote_url="turso://...",
     partial_sync_opts=turso.sync.PartialSyncOpts(
         bootstrap_strategy=turso.sync.PartialSyncQueryBootstrap(
             query="SELECT * FROM messages WHERE user_id = 'u_123' LIMIT 100"
@@ -123,7 +123,7 @@ import (
 
 db, err := turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
   Path:            "./app.db",
-  RemoteUrl:       "libsql://...",
+  RemoteUrl:       "turso://...",
   RemoteAuthToken: os.Getenv("TURSO_AUTH_TOKEN"),
   PartialSyncConfig: turso.TursoPartialSyncConfig{
     BoostrapStrategyQuery: "SELECT * FROM messages WHERE user_id = 'u_123' LIMIT 100",

--- a/sync/partial.mdx
+++ b/sync/partial.mdx
@@ -300,8 +300,8 @@ turso.sync.connect(
 ```go Go
 turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
   ...
-  PartialSyncConfig: turso.TursoPartialSyncConfig{
-    BoostrapStrategyPrefix: 128 * 1024, // 128 KiB
+  PartialSyncExperimental: turso.TursoPartialSyncConfig{
+    BootstrapStrategyPrefix: 128 * 1024, // 128 KiB
     SegmentSize: 16 * 1024,
   },
 })
@@ -442,8 +442,8 @@ turso.sync.connect(
 ```go Go
 turso.NewTursoSyncDb(context.Background(), turso.TursoSyncDbConfig{
   ...
-  PartialSyncConfig: turso.TursoPartialSyncConfig{
-    BoostrapStrategyPrefix: 128 * 1024, // 128 KiB
+  PartialSyncExperimental: turso.TursoPartialSyncConfig{
+    BootstrapStrategyPrefix: 128 * 1024, // 128 KiB
     Prefetch: true,
   },
 })

--- a/sync/partial.mdx
+++ b/sync/partial.mdx
@@ -58,7 +58,7 @@ import turso.sync
 conn = turso.sync.connect(
     path="./app.db",
     remote_url="turso://...",
-    remote_auth_token=os.environ["TURSO_AUTH_TOKEN"],
+    auth_token=os.environ["TURSO_AUTH_TOKEN"],
     partial_sync_opts=turso.sync.PartialSyncOpts(
         bootstrap_strategy=turso.sync.PartialSyncPrefixBootstrap(length=128 * 1024),
     ),

--- a/sync/partial.mdx
+++ b/sync/partial.mdx
@@ -59,7 +59,7 @@ conn = turso.sync.connect(
     path="./app.db",
     remote_url="turso://...",
     auth_token=os.environ["TURSO_AUTH_TOKEN"],
-    partial_sync_opts=turso.sync.PartialSyncOpts(
+    partial_sync_experimental=turso.sync.PartialSyncOpts(
         bootstrap_strategy=turso.sync.PartialSyncPrefixBootstrap(length=128 * 1024),
     ),
 )
@@ -108,7 +108,7 @@ import turso.sync
 conn = turso.sync.connect(
     path=":memory:",
     remote_url="turso://...",
-    partial_sync_opts=turso.sync.PartialSyncOpts(
+    partial_sync_experimental=turso.sync.PartialSyncOpts(
         bootstrap_strategy=turso.sync.PartialSyncQueryBootstrap(
             query="SELECT * FROM messages WHERE user_id = 'u_123' LIMIT 100"
         ),
@@ -290,7 +290,7 @@ await connect({
 ```py Python
 turso.sync.connect(
     ...
-    partial_sync_opts=turso.sync.PartialSyncOpts(
+    partial_sync_experimental=turso.sync.PartialSyncOpts(
         bootstrap_strategy=turso.sync.PartialSyncPrefixBootstrap(length=128 * 1024),
         segment_size=16 * 1024,
     ),
@@ -432,7 +432,7 @@ await connect({
 ```py Python
 turso.sync.connect(
     ...
-    partial_sync_opts=turso.sync.PartialSyncOpts(
+    partial_sync_experimental=turso.sync.PartialSyncOpts(
         bootstrap_strategy=turso.sync.PartialSyncPrefixBootstrap(length=128 * 1024),
         prefetch=True,
     ),

--- a/sync/usage.mdx
+++ b/sync/usage.mdx
@@ -55,7 +55,7 @@ import turso.sync
 conn = turso.sync.connect(
     path="./app.db",                                  # local path
     remote_url="turso://...",                        # remote URL (generated with turso db show <db-name> --url)
-    remote_auth_token=os.environ["TURSO_AUTH_TOKEN"], # authentication token (generated with turso db tokens create <db-name>)
+    auth_token=os.environ["TURSO_AUTH_TOKEN"],        # authentication token (generated with turso db tokens create <db-name>)
     # long_poll_timeout_ms=10_000,                    # optional: server waits before replying to pull
     # bootstrap_if_empty=False,                       # set to false to avoid bootstrapping on first run
 )
@@ -291,7 +291,7 @@ import turso.sync
 conn = turso.sync.connect(
     path="./local.db",
     remote_url=os.environ["TURSO_URL"],
-    remote_auth_token=os.environ["TURSO_AUTH_TOKEN"],
+    auth_token=os.environ["TURSO_AUTH_TOKEN"],
     bootstrap_if_empty=False,
 )
 

--- a/sync/usage.mdx
+++ b/sync/usage.mdx
@@ -65,15 +65,15 @@ conn = turso.sync.connect(
 package main
 
 import (
-	"turso"
+	turso "turso.tech/database/tursogo"
 )
 
 db, err := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{
   Path:              "./app.db",                    // local path
   RemoteUrl:         "turso://...",                // remote URL (generated with turso db show <db-name> --url)
-  RemoteAuthToken:   os.Getenv("TURSO_AUTH_TOKEN"), // authentication token (generated with turso db tokens create <db-name>)
+  AuthToken:         os.Getenv("TURSO_AUTH_TOKEN"), // authentication token (generated with turso db tokens create <db-name>)
   // LongPollTimeoutMs: 10_000,                     // optional: server waits before replying to pull
-  // BootstrapIfEmpty: false,                       // set to false to avoid bootstrapping on first run
+  // BootstrapIfEmpty: new(bool),                   // *bool; point at false to avoid bootstrapping on first run
 })
 ```
 
@@ -315,13 +315,14 @@ sync_when_online(conn)
 ```
 
 ```go Go
-// BootstrapIfEmpty: false lets the app start offline without
-// needing to reach the remote on first launch
+// BootstrapIfEmpty pointing at false lets the app start offline
+// without needing to reach the remote on first launch
+noBootstrap := false
 db, err := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{
 	Path:             "./local.db",
 	RemoteUrl:        os.Getenv("TURSO_URL"),
-	RemoteAuthToken:  os.Getenv("TURSO_AUTH_TOKEN"),
-	BootstrapIfEmpty: false,
+	AuthToken:        os.Getenv("TURSO_AUTH_TOKEN"),
+	BootstrapIfEmpty: &noBootstrap,
 })
 
 func syncWhenOnline(ctx context.Context, db *turso.TursoSyncDb) {

--- a/sync/usage.mdx
+++ b/sync/usage.mdx
@@ -15,7 +15,7 @@ This particular usage uses the Turso Cloud to sync the local Turso databases and
 
 - Follow our [Quickstart](/quickstart) to install the CLI, create a database
 
-- Get the database URL (`libsql://...`):
+- Get the database URL (`turso://...`):
 ```
 turso db show <db>
 ```
@@ -31,7 +31,7 @@ turso db tokens create <db>
 
 You need three essentials to enable sync:
 - Local path: where the local, synced tursodb file is stored
-- Remote URL: your Turso Cloud URL (`libsql://...`)
+- Remote URL: your Turso Cloud URL (`turso://...`)
 - Auth token: Turso Cloud token to authenticate requests
 
 <CodeGroup>
@@ -41,7 +41,7 @@ import { connect } from '@tursodatabase/sync';
 
 const db = await connect({
   path: './app.db',                               // local path
-  url: 'libsql://...',                            // remote URL (generated with turso db show <db-name> --url)
+  url: 'turso://...',                            // remote URL (generated with turso db show <db-name> --url)
   authToken: process.env.TURSO_AUTH_TOKEN,        // authentication token (generated with turso db tokens create <db-name>)
   // longPollTimeoutMs: 10_000,                   // optional: server waits before replying to pull
   // bootstrapIfEmpty: false,                     // set to false to avoid bootstrapping on first run
@@ -54,7 +54,7 @@ import turso.sync
 
 conn = turso.sync.connect(
     path="./app.db",                                  # local path
-    remote_url="libsql://...",                        # remote URL (generated with turso db show <db-name> --url)
+    remote_url="turso://...",                        # remote URL (generated with turso db show <db-name> --url)
     remote_auth_token=os.environ["TURSO_AUTH_TOKEN"], # authentication token (generated with turso db tokens create <db-name>)
     # long_poll_timeout_ms=10_000,                    # optional: server waits before replying to pull
     # bootstrap_if_empty=False,                       # set to false to avoid bootstrapping on first run
@@ -70,7 +70,7 @@ import (
 
 db, err := turso.NewTursoSyncDb(ctx, turso.TursoSyncDbConfig{
   Path:              "./app.db",                    // local path
-  RemoteUrl:         "libsql://...",                // remote URL (generated with turso db show <db-name> --url)
+  RemoteUrl:         "turso://...",                // remote URL (generated with turso db show <db-name> --url)
   RemoteAuthToken:   os.Getenv("TURSO_AUTH_TOKEN"), // authentication token (generated with turso db tokens create <db-name>)
   // LongPollTimeoutMs: 10_000,                     // optional: server waits before replying to pull
   // BootstrapIfEmpty: false,                       // set to false to avoid bootstrapping on first run

--- a/turso-cloud.mdx
+++ b/turso-cloud.mdx
@@ -1,16 +1,20 @@
 ---
 title: Turso Cloud Documentation
-description: Your fully managed SQLite-compatible database platform built on libSQL
+description: Fully managed platform for SQLite-compatible databases. Deploy Turso, a rewrite of SQLite with concurrent writes and multi-user access built in, or libSQL, the battle-tested SQLite fork. No need to switch to Postgres for concurrency.
 sidebarTitle: Introduction
 ---
 
-<Note>
-  Turso Cloud currently runs on **libSQL** (SQLite-compatible). The
-  next-generation Turso Database engine is in alpha development and will be
-  integrated into Turso Cloud in the future.
-</Note>
+Turso Cloud is a fully managed database platform, designed to scale from prototype to production. It hosts two database engines, both fully compatible with SQLite:
 
-Turso Cloud is your fully managed SQLite-compatible database platform, designed to scale from prototype to production. Built on [libSQL](/libsql), Turso Cloud provides the performance and reliability of SQLite with the convenience and scalability of a modern cloud database service.
+- **[Turso](/tursodb/quickstart)** — a ground-up rewrite of SQLite. Turso supports **concurrent writes** and **multi-user access by default**: many clients can read and write the same database at the same time, over the network. If SQLite's single-writer limitation is what would push you toward a client-server database like Postgres, Turso removes it — you keep SQLite's simplicity and compatibility and gain the concurrency. Concurrent writes are the headline, but not the whole story: see the [Turso documentation](/tursodb/quickstart) for change data capture, vector search, encryption, sync, and more.
+
+- **[libSQL](/libsql)** — a fork of SQLite, battle-tested in production on Turso Cloud for years.
+
+<Note>
+  Turso databases on Turso Cloud are in early preview — a reflection of how
+  recently the offering landed on the platform, not of the engine itself.
+  Create one with `turso db create --tursodb`.
+</Note>
 
 <CardGroup cols={2}>
   <Card
@@ -258,8 +262,8 @@ Learn how to manage, distribute and integrate your databases with the CLI, API a
     }
     href="/sdk"
   >
-    Connect and integrate Turso into your application with one of our libSQL
-    drivers.
+    Connect and integrate your application with one of our client SDKs, for
+    Turso and libSQL databases alike.
   </Card>
   <Card title="Tutorials" icon="newspaper" href="https://turso.tech/blog">
     Learn how to work with Turso and your favorite language or framework.


### PR DESCRIPTION
Turso (the ground-up rewrite of SQLite) is now available on Turso Cloud. This PR makes the docs reflect that and removes the libSQL/Turso mixing that made our recommendations confusing.

## What changed

**Turso Cloud is a platform for both engines.** The Cloud introduction now opens with the two SQLite-compatible engines: **Turso** — concurrent writes and multi-user access by default, so users (and LLMs reading the page description) moving off SQLite over concurrency don't conclude they need Postgres — and **libSQL**, the battle-tested fork. The early-preview note appears only in the introduction, framed as recency of the offering on the platform, with a link to the in-tree Turso docs for the full feature set. The Cloud quickstart now creates a Turso database first (`turso db create --tursodb`), libSQL as the alternative.

**One recommendation rule everywhere:**
1. If a local database is involved — fully local, or local with sync (even when the remote is libSQL) — use the Turso packages.
2. Remote-only access matches the driver to the engine:

| | TypeScript | Python | Go | Rust |
| --- | --- | --- | --- | --- |
| Remote Turso database | `@tursodatabase/serverless` | `turso_serverless` | `tursogo-serverless` | `turso_serverless` |
| Remote libSQL database | `@libsql/client` | `libsql` | `libsql-client-go` | `libsql` (`remote`) |

This reverts the earlier serverless-for-everything JS advice: libSQL cloud databases are back on `@libsql/client`. The new Rust/Python/Go serverless drivers are documented in the quickstarts and reference tables.

**`turso://` URLs** are used for Turso cloud databases, `libsql://` for libSQL — stated plainly, no dual-scheme caveats. This includes the sync examples, which assume the upcoming sync release accepts `turso://` (see caveats). AgentFS is its own thing and is left untouched.

**Beta label removed** from the Turso Database tab (docs.json + the sync script constant that locates the tab).

## Bugs fixed along the way (found by running the examples)

- `sdk/authorization.mdx` / `jwks.mdx` imported `createClient` from `@tursodatabase/serverless` — it only exists in `/compat`; examples now use `connect`.
- The agentic Vercel and Stripe guides chained `.all()`/`.get()`/`.run()` off async `prepare()` (throws at runtime) and used `conn.transaction("write")` — the API takes a function. Only the code examples were fixed; the guides' recommendations are untouched.
- Missing `await conn.prepare(...)` in the HTTP quickstart and Vercel page.

## Testing

Every new example was run against a live `--tursodb` cloud database with the published packages: `@tursodatabase/serverless@1.3.2`, `turso_serverless` 0.1.0 (PyPI and crates.io), `tursogo-serverless` via `go get`, plus the four local-package examples and `@tursodatabase/sync`. All four serverless drivers were also verified to accept `turso://` URLs. Test databases were destroyed afterwards. Mintlify link check reports only the 7 pre-existing broken links (untouched here).

## Caveats / follow-ups

- The currently published `@tursodatabase/sync` still rejects `turso://`; the sync examples assume the next release accepts it. A final validation pass before shipping will re-run those examples against the released packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




