### PR TITLE
docs(mcp): Cursor add-marketplace dialog requires the full GitHub URL

### DIFF
--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -61,8 +61,8 @@ apart and confirm before doing anything that changes data.
   <Tab title="Cursor">
 
   Install the plugin (it bundles the Turso skill too): open **Customize →
-  Plugins → Add marketplace**, enter `tursodatabase/turso-mcp`, and install
-  **Turso** from it. Then open **Settings → MCP**, select **turso**, and follow
+  Plugins → Add marketplace**, enter `https://github.com/tursodatabase/turso-mcp`,
+  and install **Turso** from it. Then open **Settings → MCP**, select **turso**, and follow
   the login prompt to approve access (see [Authorize](#authorize-access) below).
 
   One-click alternative (MCP server only, no skill):


### PR DESCRIPTION
Follow-up to #413, which merged before this commit landed on the branch (GitHub served a stale head). The add-marketplace dialog in Cursor rejects the short `owner/repo` form — silently, no error — and only accepts a full URL. Update the Cursor tab to say `https://github.com/tursodatabase/turso-mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)