### PR TITLE
docs: add LibreDB Studio to the GUI tools list

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -146,3 +146,4 @@ During development you can easily connect to a SQLite, libSQL, or Turso database
 - [Dataflare](https://dataflare.app) &mdash; Paid (with limited free version) macOS, Windows, and Linux
 - [Outerbase Studio](https://libsqlstudio.com) - Runs in the browser
 - [DBeaver](https://dbeaver.io) - macOS, Windows, and Linux
+- [LibreDB Studio](https://github.com/libredb/libredb-studio) - Self-hosted, runs in the browser, connects over libSQL/Hrana


### PR DESCRIPTION
LibreDB Studio is an open source, self-hosted SQL IDE that runs in the browser. It connects to libSQL servers and Turso Cloud over the Hrana protocol, so it fits the list of GUI tools on this page.

I maintain LibreDB Studio.

Repository: https://github.com/libredb/libredb-studio
